### PR TITLE
Cash flow ordering, asset/channel types, mobile usability fixes

### DIFF
--- a/alembic/versions/c1a2b3d4e5f6_add_asset_channel.py
+++ b/alembic/versions/c1a2b3d4e5f6_add_asset_channel.py
@@ -1,0 +1,27 @@
+"""add asset channel
+
+Revision ID: c1a2b3d4e5f6
+Revises: 8ff13437c567
+Create Date: 2026-07-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c1a2b3d4e5f6'
+down_revision: Union[str, None] = '8ff13437c567'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('assets', sa.Column('channel_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'assets', 'channels', ['channel_id'], ['id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, 'assets', type_='foreignkey')
+    op.drop_column('assets', 'channel_id')

--- a/alembic/versions/d2b3c4e5f6a7_add_channel_type.py
+++ b/alembic/versions/d2b3c4e5f6a7_add_channel_type.py
@@ -1,0 +1,25 @@
+"""add channel type
+
+Revision ID: d2b3c4e5f6a7
+Revises: c1a2b3d4e5f6
+Create Date: 2026-07-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd2b3c4e5f6a7'
+down_revision: Union[str, None] = 'c1a2b3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('channels', sa.Column('channel_type', sa.String(length=30), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('channels', 'channel_type')

--- a/app/crud.py
+++ b/app/crud.py
@@ -7,6 +7,17 @@ from app import models, schemas
 
 # --- Channels ---------------------------------------------------------------
 
+CHANNEL_TYPES: tuple[str, ...] = (
+    "Traditional Bank",
+    "Digital Bank",
+    "E-Wallet",
+    "Credit Card",
+    "Time Deposit",
+    "Payment Gateway",
+    "Investment",
+    "Cash",
+)
+
 
 class ChannelInUseError(Exception):
     """Raised when deleting a channel that is still referenced elsewhere."""
@@ -22,7 +33,10 @@ def list_channels(db: Session) -> list[models.Channel]:
 
 def create_channel(db: Session, data: schemas.ChannelCreate) -> models.Channel:
     channel = models.Channel(
-        name=data.name, color=data.color, funding_source_channel_id=data.funding_source_channel_id
+        name=data.name,
+        color=data.color,
+        channel_type=data.channel_type,
+        funding_source_channel_id=data.funding_source_channel_id,
     )
     db.add(channel)
     db.commit()
@@ -39,6 +53,7 @@ def update_channel(
     if channel is not None:
         channel.name = data.name
         channel.color = data.color
+        channel.channel_type = data.channel_type
         channel.funding_source_channel_id = data.funding_source_channel_id
         db.commit()
         db.refresh(channel)
@@ -294,6 +309,7 @@ def update_asset(db: Session, asset_id: int, data: schemas.AssetUpdate) -> model
     if asset is not None:
         asset.name = data.name
         asset.amount = data.amount
+        asset.channel_id = data.channel_id
         db.commit()
         db.refresh(asset)
     return asset
@@ -308,7 +324,11 @@ def delete_asset(db: Session, asset_id: int) -> None:
 
 def assets_page_data(db: Session) -> dict:
     assets = list_assets(db)
-    return {"assets": assets, "total_assets": sum(float(a.amount) for a in assets)}
+    return {
+        "assets": assets,
+        "total_assets": sum(float(a.amount) for a in assets),
+        "channels": list_channels(db),
+    }
 
 
 # --- Goals -----------------------------------------------------------------
@@ -450,21 +470,91 @@ def overview_page_data(db: Session) -> dict:
 def expenses_page_data(db: Session) -> dict:
     return {
         "channels": list_channels(db),
+        "channel_types": CHANNEL_TYPES,
         "payout_periods": list_payout_periods(db),
         "expenses": list_expenses(db),
     }
 
 
+def _order_transfers(
+    channels: list[models.Channel], transfers: list[models.Transfer]
+) -> list[models.Transfer]:
+    """Order transfers by which should be done first: a transfer out of a
+    channel can't happen (in a real sense) until any transfer funding that
+    channel has already landed, so sort by each transfer's from_channel's
+    topological depth in the transfer graph (Kahn's algorithm), tie-broken
+    by id for stability."""
+    graph: dict[int, set[int]] = {c.id: set() for c in channels}
+    indegree: dict[int, int] = dict.fromkeys(graph, 0)
+    for t in transfers:
+        if t.to_channel_id not in graph[t.from_channel_id]:
+            graph[t.from_channel_id].add(t.to_channel_id)
+            indegree[t.to_channel_id] += 1
+
+    depth: dict[int, int] = {}
+    ready = sorted(cid for cid, d in indegree.items() if d == 0)
+    while ready:
+        cid = ready.pop(0)
+        depth[cid] = len(depth)
+        for nxt in sorted(graph[cid]):
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                ready.append(nxt)
+        ready.sort()
+    for cid in graph:
+        if cid not in depth:
+            depth[cid] = len(depth)
+
+    return sorted(transfers, key=lambda t: (depth[t.from_channel_id], t.id))
+
+
+def _peso(amount: float) -> str:
+    sign = "-" if amount < 0 else ""
+    return f"{sign}₱{abs(amount):,.2f}"
+
+
+def _transfer_note(
+    to_channel_id: int,
+    expenses: list[models.Expense],
+    goals: list[models.Goal],
+    payout_period_count: int,
+) -> str:
+    parts = [
+        f"{e.name} ({_peso(float(e.amount))})" for e in expenses if e.channel_id == to_channel_id
+    ]
+    parts += [
+        f"{g.name} goal ({_peso(goal_payout_amount(g, payout_period_count))})"
+        for g in goals
+        if g.channel_id == to_channel_id
+    ]
+    if not parts:
+        return "No expenses or goals tagged to this channel for this payout yet."
+    return "Covers: " + ", ".join(parts)
+
+
 def cashflow_page_data(db: Session) -> dict:
     payout_periods = list_payout_periods(db)
-    return {
-        "channels": list_channels(db),
-        "payout_data": [
+    channels = list_channels(db)
+    goals = list_goals(db)
+    all_expenses = list_expenses(db)
+    payout_period_count = len(payout_periods)
+    payout_data = []
+    for period in payout_periods:
+        expenses = [e for e in all_expenses if e.payout_period_id == period.id]
+        transfers = _order_transfers(channels, list_transfers(db, period.id))
+        payout_data.append(
             {
                 "period": period,
-                "transfers": list_transfers(db, period.id),
+                "transfers": [
+                    {
+                        "transfer": t,
+                        "note": _transfer_note(
+                            t.to_channel_id, expenses, goals, payout_period_count
+                        ),
+                    }
+                    for t in transfers
+                ],
                 "balances": channel_balances(db, period.id),
             }
-            for period in payout_periods
-        ],
-    }
+        )
+    return {"channels": channels, "payout_data": payout_data}

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,6 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
-from app import crud
 from app.database import get_db
 from app.routers import (
     assets,
@@ -38,7 +37,7 @@ PLACEHOLDER_SECTIONS: dict[str, str] = {}
 
 @app.get("/")
 def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    return templates.TemplateResponse(request, "expenses.html", crud.expenses_page_data(db))
+    return overview.index(request, db)
 
 
 @app.get("/{section}")

--- a/app/models.py
+++ b/app/models.py
@@ -10,6 +10,7 @@ class Channel(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     color: Mapped[str] = mapped_column(String(7), default="#8a8a8a")
+    channel_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
     funding_source_channel_id: Mapped[int | None] = mapped_column(
         ForeignKey("channels.id"), nullable=True
     )
@@ -90,3 +91,6 @@ class Asset(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     amount: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    channel_id: Mapped[int | None] = mapped_column(ForeignKey("channels.id"), nullable=True)
+
+    channel: Mapped[Channel | None] = relationship()

--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -16,9 +16,14 @@ def _render_page(request: Request, db: Session) -> HTMLResponse:
     )
 
 
+def _parse_channel_id(raw: str) -> int | None:
+    return int(raw) if raw else None
+
+
 @router.get("")
 def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    return templates.TemplateResponse(request, "assets.html", crud.assets_page_data(db))
+    template = "partials/assets_page.html" if request.headers.get("HX-Request") else "assets.html"
+    return templates.TemplateResponse(request, template, crud.assets_page_data(db))
 
 
 @router.post("")
@@ -26,9 +31,12 @@ def create_asset(
     request: Request,
     name: str = Form(...),
     amount: float = Form(...),
+    channel_id: str = Form(""),
     db: Session = Depends(get_db),
 ) -> HTMLResponse:
-    crud.create_asset(db, schemas.AssetCreate(name=name, amount=amount))
+    crud.create_asset(
+        db, schemas.AssetCreate(name=name, amount=amount, channel_id=_parse_channel_id(channel_id))
+    )
     return _render_page(request, db)
 
 
@@ -38,9 +46,14 @@ def update_asset(
     asset_id: int,
     name: str = Form(...),
     amount: float = Form(...),
+    channel_id: str = Form(""),
     db: Session = Depends(get_db),
 ) -> HTMLResponse:
-    crud.update_asset(db, asset_id, schemas.AssetUpdate(name=name, amount=amount))
+    crud.update_asset(
+        db,
+        asset_id,
+        schemas.AssetUpdate(name=name, amount=amount, channel_id=_parse_channel_id(channel_id)),
+    )
     return _render_page(request, db)
 
 

--- a/app/routers/cashflow.py
+++ b/app/routers/cashflow.py
@@ -12,4 +12,7 @@ templates = Jinja2Templates(directory="app/templates")
 
 @router.get("")
 def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    return templates.TemplateResponse(request, "cashflow.html", crud.cashflow_page_data(db))
+    template = (
+        "partials/cashflow_page.html" if request.headers.get("HX-Request") else "cashflow.html"
+    )
+    return templates.TemplateResponse(request, template, crud.cashflow_page_data(db))

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -25,6 +25,7 @@ def create_channel(
     request: Request,
     name: str = Form(...),
     color: str = Form("#8a8a8a"),
+    channel_type: str = Form(""),
     funding_source_channel_id: str = Form(""),
     db: Session = Depends(get_db),
 ) -> HTMLResponse:
@@ -33,6 +34,7 @@ def create_channel(
         schemas.ChannelCreate(
             name=name,
             color=color,
+            channel_type=channel_type or None,
             funding_source_channel_id=_parse_channel_id(funding_source_channel_id),
         ),
     )
@@ -45,6 +47,7 @@ def update_channel(
     channel_id: int,
     name: str = Form(...),
     color: str = Form(...),
+    channel_type: str = Form(""),
     funding_source_channel_id: str = Form(""),
     db: Session = Depends(get_db),
 ) -> HTMLResponse:
@@ -55,6 +58,7 @@ def update_channel(
             schemas.ChannelUpdate(
                 name=name,
                 color=color,
+                channel_type=channel_type or None,
                 funding_source_channel_id=_parse_channel_id(funding_source_channel_id),
             ),
         )

--- a/app/routers/credit.py
+++ b/app/routers/credit.py
@@ -22,7 +22,8 @@ def _parse_channel_id(raw: str) -> int | None:
 
 @router.get("")
 def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    return templates.TemplateResponse(request, "credit.html", crud.credit_page_data(db))
+    template = "partials/credit_page.html" if request.headers.get("HX-Request") else "credit.html"
+    return templates.TemplateResponse(request, template, crud.credit_page_data(db))
 
 
 @router.post("")

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -16,6 +16,14 @@ def _render_page(request: Request, db: Session) -> HTMLResponse:
     )
 
 
+@router.get("")
+def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    template = (
+        "partials/expenses_page.html" if request.headers.get("HX-Request") else "expenses.html"
+    )
+    return templates.TemplateResponse(request, template, crud.expenses_page_data(db))
+
+
 @router.post("")
 def create_expense(
     request: Request,

--- a/app/routers/goals.py
+++ b/app/routers/goals.py
@@ -22,7 +22,8 @@ def _parse_channel_id(raw: str) -> int | None:
 
 @router.get("")
 def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    return templates.TemplateResponse(request, "goals.html", crud.goals_page_data(db))
+    template = "partials/goals_page.html" if request.headers.get("HX-Request") else "goals.html"
+    return templates.TemplateResponse(request, template, crud.goals_page_data(db))
 
 
 @router.post("")

--- a/app/routers/overview.py
+++ b/app/routers/overview.py
@@ -12,4 +12,7 @@ templates = Jinja2Templates(directory="app/templates")
 
 @router.get("")
 def index(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
-    return templates.TemplateResponse(request, "overview.html", crud.overview_page_data(db))
+    template = (
+        "partials/overview_page.html" if request.headers.get("HX-Request") else "overview.html"
+    )
+    return templates.TemplateResponse(request, template, crud.overview_page_data(db))

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -4,12 +4,14 @@ from pydantic import BaseModel
 class ChannelCreate(BaseModel):
     name: str
     color: str = "#8a8a8a"
+    channel_type: str | None = None
     funding_source_channel_id: int | None = None
 
 
 class ChannelUpdate(BaseModel):
     name: str
     color: str
+    channel_type: str | None = None
     funding_source_channel_id: int | None = None
 
 
@@ -45,11 +47,13 @@ class TransferUpdate(BaseModel):
 class AssetCreate(BaseModel):
     name: str
     amount: float
+    channel_id: int | None = None
 
 
 class AssetUpdate(BaseModel):
     name: str
     amount: float
+    channel_id: int | None = None
 
 
 class GoalCreate(BaseModel):

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -58,10 +58,13 @@
   }
 
   .page {
-    @apply flex-1 px-10 py-8 bg-paper overflow-y-auto;
+    @apply flex-1 px-4 py-5 sm:px-6 sm:py-6 md:px-10 md:py-8 bg-paper overflow-y-auto overflow-x-hidden;
   }
   .page-head {
-    @apply flex items-baseline justify-between mb-5;
+    @apply flex items-baseline justify-between gap-3 flex-wrap mb-5;
+  }
+  .table-wrap {
+    @apply overflow-x-auto -mx-1 px-1;
   }
   .page-title {
     @apply font-serif text-2xl font-semibold text-ink;
@@ -100,7 +103,7 @@
   }
 
   .led {
-    @apply w-full table-fixed text-[13.5px] border-collapse;
+    @apply w-full min-w-max table-fixed text-[13.5px] border-collapse;
   }
   .led th {
     @apply text-left text-[11px] uppercase tracking-wide text-ink-soft font-semibold px-2.5 py-1.5 border-b-2 border-ink;
@@ -153,5 +156,20 @@
   }
   .warn-red {
     @apply bg-rust-soft text-rust;
+  }
+}
+
+@media (max-width: 640px) {
+  .rail {
+    width: 4rem !important;
+  }
+  .rail .rail-wordmark,
+  .rail .tab-label {
+    display: none !important;
+  }
+  .rail-head {
+    flex-direction: column;
+    gap: 0.5rem;
+    justify-content: center !important;
   }
 }

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -125,7 +125,7 @@
     @apply inline-flex items-center text-ink-soft text-xs font-semibold px-3 py-1.5 rounded-md border border-line hover:bg-paper-dim cursor-pointer;
   }
   .field {
-    @apply rounded border border-line px-2.5 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-accent;
+    @apply w-full min-w-0 rounded border border-line px-2.5 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-accent;
   }
   .field-mono {
     @apply font-mono text-right;
@@ -171,5 +171,26 @@
     flex-direction: column;
     gap: 0.5rem;
     justify-content: center !important;
+  }
+  /* Width is forced above regardless of the collapsed/expanded JS state, so
+     the toggle button has no effect on mobile — hide it rather than leave a
+     dead control. */
+  #collapse-toggle {
+    display: none !important;
+  }
+
+  /* Keep inputs at >=16px so iOS Safari doesn't auto-zoom the page on focus. */
+  .field {
+    font-size: 16px;
+  }
+
+  /* Bigger tap targets for the text/icon action buttons. */
+  .icon-btn {
+    padding: 0.5rem 0.625rem;
+  }
+  .add-btn,
+  .btn-secondary {
+    padding-block: 0.625rem;
+    padding-inline: 0.875rem;
   }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,12 @@
   </head>
   <body class="font-sans text-ink">
     <div class="flex h-screen overflow-hidden bg-ink">
-      <nav class="rail" id="rail">
+      <nav class="rail"
+           id="rail"
+           hx-boost="true"
+           hx-target="#page-content"
+           hx-swap="innerHTML"
+           hx-push-url="true">
         <div class="rail-head" id="rail-head">
           <div class="rail-brand" id="rail-brand">
             <div class="rail-logo">L</div>
@@ -26,7 +31,7 @@
             <span id="collapse-icon">‹</span>
           </button>
         </div>
-        {% set nav_items = [('/overview', 'Overview', 'M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z'), ('/', 'Expenses', 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z'), ('/cashflow', 'Cash Flow', 'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5'), ('/goals', 'Goals', 'M3 3v1.5M3 21v-6m0 0l2.77-.693a9 9 0 016.208.682l.108.054a9 9 0 006.086.71l3.114-.732a48.524 48.524 0 01-.005-10.499l-3.11.732a9 9 0 01-6.085-.711l-.108-.054a9 9 0 00-6.208-.682L3 4.5M3 15V4.5'), ('/credit', 'Credit', 'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z'), ('/assets', 'Assets', 'M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75z')] %}
+        {% set nav_items = [('/', 'Overview', 'M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z'), ('/expenses', 'Expenses', 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z'), ('/cashflow', 'Cash Flow', 'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5'), ('/goals', 'Goals', 'M3 3v1.5M3 21v-6m0 0l2.77-.693a9 9 0 016.208.682l.108.054a9 9 0 006.086.71l3.114-.732a48.524 48.524 0 01-.005-10.499l-3.11.732a9 9 0 01-6.085-.711l-.108-.054a9 9 0 00-6.208-.682L3 4.5M3 15V4.5'), ('/credit', 'Credit', 'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z'), ('/assets', 'Assets', 'M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75z')] %}
         {% for href, label, icon_path in nav_items %}
           <a class="tab{{ ' tab-active' if request.url.path == href else '' }}"
              href="{{ href }}">
@@ -41,7 +46,7 @@
           </a>
         {% endfor %}
       </nav>
-      <div class="page">
+      <div class="page" id="page-content">
         {% block content %}
         {% endblock content %}
       </div>
@@ -189,6 +194,17 @@
         const amountInput = selectEl.closest("tr").querySelector('input[name="amount"]');
         if (amountInput) amountInput.value = opt.dataset.needed;
       }
+
+      function updateActiveTab() {
+        const path = location.pathname;
+        document.querySelectorAll(".tab").forEach((tab) => {
+          tab.classList.toggle("tab-active", tab.getAttribute("href") === path);
+        });
+      }
+
+      document.body.addEventListener("htmx:afterSettle", (evt) => {
+        if (evt.detail.target && evt.detail.target.id === "page-content") updateActiveTab();
+      });
     </script>
   </body>
 </html>

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -4,6 +4,12 @@
   <span class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }}"
         style="background: {{ channel.color }}">{{ initials }}</span>
 {% endmacro %}
+{% macro channel_name(channel, max_len=18) %}
+  <span title="{{ channel.name }}">{{ channel.name|truncate(max_len, True, '…') }}</span>
+{% endmacro %}
+{% macro channel_label(channel, size=15, max_len=18) %}
+  {{ channel_badge(channel, size) }} {{ channel_name(channel, max_len) }}
+{% endmacro %}
 {% macro empty_row(colspan, label) %}
   <tr>
     <td colspan="{{ colspan }}"

--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -20,7 +20,7 @@
     <div class="table-wrap">
       <table class="led">
         <colgroup>
-          <col>
+          <col class="min-w-28">
           <col class="w-40">
           <col class="w-32">
           <col class="w-28">

--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -1,4 +1,4 @@
-{% import "macros.html" as macros %}
+﻿{% import "macros.html" as macros %}
 <div id="assets-page">
   <div class="page-head">
     <div>
@@ -17,101 +17,130 @@
           hx-target="#assets-page"
           hx-swap="outerHTML">
     </form>
-    <table class="led">
-      <colgroup>
-        <col>
-        <col class="w-32">
-        <col class="w-28">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th class="text-right">Amount</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for asset in assets %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col>
+          <col class="w-40">
+          <col class="w-32">
+          <col class="w-28">
+        </colgroup>
+        <thead>
           <tr>
+            <th>Name</th>
+            <th>Channel</th>
+            <th class="text-right">Amount</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for asset in assets %}
+            <tr>
+              <td>
+                <span class="view-asset-{{ asset.id }}">{{ asset.name }}</span>
+                <form id="asset-edit-form-{{ asset.id }}"
+                      hx-patch="/assets/{{ asset.id }}"
+                      hx-target="#assets-page"
+                      hx-swap="outerHTML"
+                      class="edit-asset-{{ asset.id }} hidden items-center gap-2">
+                  <input class="field" type="text" name="name" value="{{ asset.name }}">
+                </form>
+              </td>
+              <td>
+                <span class="view-asset-{{ asset.id }}">
+                  {% if asset.channel %}
+                    {{ macros.channel_label(asset.channel) }}
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </span>
+                <div class="edit-asset-{{ asset.id }} hidden items-center gap-1">
+                  <select class="field" name="channel_id" form="asset-edit-form-{{ asset.id }}">
+                    <option value="">No channel</option>
+                    {% for channel in channels %}
+                      <option value="{{ channel.id }}"
+                              {{ "selected" if asset.channel_id == channel.id else "" }}>{{ channel.name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </td>
+              <td class="num">
+                <span class="view-asset-{{ asset.id }}">{{ macros.peso(asset.amount) }}</span>
+                <div class="edit-asset-{{ asset.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">&#8369;</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="amount"
+                         form="asset-edit-form-{{ asset.id }}"
+                         value="{{ asset.amount }}">
+                </div>
+              </td>
+              <td>
+                <div class="view-asset-{{ asset.id }} flex items-center gap-1">
+                  <button type="button"
+                          class="icon-btn hover:bg-accent/15 hover:text-accent"
+                          onclick="toggleEditMode('asset-{{ asset.id }}')">Edit</button>
+                  <button class="icon-btn"
+                          hx-delete="/assets/{{ asset.id }}"
+                          hx-target="#assets-page"
+                          hx-swap="outerHTML"
+                          hx-confirm="Delete this asset?">Delete</button>
+                </div>
+                <div class="edit-asset-{{ asset.id }} hidden items-center gap-1">
+                  <button type="submit"
+                          form="asset-edit-form-{{ asset.id }}"
+                          class="add-btn mt-0">Save</button>
+                  <button type="button"
+                          class="btn-secondary"
+                          onclick="cancelEdit('asset-{{ asset.id }}', 'asset-edit-form-{{ asset.id }}')">Cancel</button>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(4, 'assets') }}
+          {% endfor %}
+          <tr>
+            <td colspan="4">
+              <button type="button"
+                      class="add-btn w-20 justify-center"
+                      onclick="toggleAddRow('add-asset-row', this)">+ Add</button>
+            </td>
+          </tr>
+          <tr id="add-asset-row" class="hidden">
             <td>
-              <span class="view-asset-{{ asset.id }}">{{ asset.name }}</span>
-              <form id="asset-edit-form-{{ asset.id }}"
-                    hx-patch="/assets/{{ asset.id }}"
-                    hx-target="#assets-page"
-                    hx-swap="outerHTML"
-                    class="edit-asset-{{ asset.id }} hidden items-center gap-2">
-                <input class="field" type="text" name="name" value="{{ asset.name }}">
-              </form>
+              <input class="field"
+                     type="text"
+                     name="name"
+                     form="add-asset-form"
+                     placeholder="Asset name"
+                     required>
+            </td>
+            <td>
+              <select class="field" name="channel_id" form="add-asset-form">
+                <option value="">No channel</option>
+                {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
+              </select>
             </td>
             <td class="num">
-              <span class="view-asset-{{ asset.id }}">{{ macros.peso(asset.amount) }}</span>
-              <div class="edit-asset-{{ asset.id }} hidden items-center justify-end gap-1">
+              <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">&#8369;</span>
                 <input class="field field-mono w-24"
                        type="number"
                        step="0.01"
                        name="amount"
-                       form="asset-edit-form-{{ asset.id }}"
-                       value="{{ asset.amount }}">
+                       form="add-asset-form"
+                       placeholder="Amount"
+                       required>
               </div>
             </td>
             <td>
-              <div class="view-asset-{{ asset.id }} flex items-center gap-1">
-                <button type="button"
-                        class="icon-btn hover:bg-accent/15 hover:text-accent"
-                        onclick="toggleEditMode('asset-{{ asset.id }}')">Edit</button>
-                <button class="icon-btn"
-                        hx-delete="/assets/{{ asset.id }}"
-                        hx-target="#assets-page"
-                        hx-swap="outerHTML"
-                        hx-confirm="Delete this asset?">Delete</button>
-              </div>
-              <div class="edit-asset-{{ asset.id }} hidden items-center gap-1">
-                <button type="submit"
-                        form="asset-edit-form-{{ asset.id }}"
-                        class="add-btn mt-0">Save</button>
-                <button type="button"
-                        class="btn-secondary"
-                        onclick="cancelEdit('asset-{{ asset.id }}', 'asset-edit-form-{{ asset.id }}')">Cancel</button>
-              </div>
+              <button class="add-btn" type="submit" form="add-asset-form">Add</button>
             </td>
           </tr>
-        {% else %}
-          {{ macros.empty_row(3, 'assets') }}
-        {% endfor %}
-        <tr>
-          <td colspan="3">
-            <button type="button"
-                    class="add-btn w-20 justify-center"
-                    onclick="toggleAddRow('add-asset-row', this)">+ Add</button>
-          </td>
-        </tr>
-        <tr id="add-asset-row" class="hidden">
-          <td>
-            <input class="field"
-                   type="text"
-                   name="name"
-                   form="add-asset-form"
-                   placeholder="Asset name"
-                   required>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="amount"
-                     form="add-asset-form"
-                     placeholder="Amount"
-                     required>
-            </div>
-          </td>
-          <td>
-            <button class="add-btn" type="submit" form="add-asset-form">Add</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/templates/partials/cashflow_page.html
+++ b/app/templates/partials/cashflow_page.html
@@ -37,8 +37,8 @@
       <div class="table-wrap">
         <table class="led">
           <colgroup>
-            <col>
-            <col>
+            <col class="min-w-28">
+            <col class="min-w-28">
             <col class="w-24">
             <col class="w-28">
           </colgroup>

--- a/app/templates/partials/cashflow_page.html
+++ b/app/templates/partials/cashflow_page.html
@@ -1,4 +1,4 @@
-{% import "macros.html" as macros %}
+﻿{% import "macros.html" as macros %}
 <div id="cashflow-page">
   <div class="page-head">
     <div>
@@ -26,120 +26,124 @@
             hx-swap="outerHTML">
         <input type="hidden" name="payout_period_id" value="{{ data.period.id }}">
       </form>
-      {% for transfer in data.transfers %}
+      {% for item in data.transfers %}
+        {% set transfer = item.transfer %}
         <form id="edit-transfer-form-{{ transfer.id }}"
               hx-patch="/transfers/{{ transfer.id }}"
               hx-target="#cashflow-page"
               hx-swap="outerHTML">
         </form>
       {% endfor %}
-      <table class="led">
-        <colgroup>
-          <col>
-          <col>
-          <col class="w-24">
-          <col class="w-28">
-        </colgroup>
-        <thead>
-          <tr>
-            <th>From</th>
-            <th>To</th>
-            <th class="text-right">Amount</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for transfer in data.transfers %}
+      <div class="table-wrap">
+        <table class="led">
+          <colgroup>
+            <col>
+            <col>
+            <col class="w-24">
+            <col class="w-28">
+          </colgroup>
+          <thead>
             <tr>
-              <td>{{ macros.channel_badge(transfer.from_channel, 15) }} {{ transfer.from_channel.name }}</td>
-              <td>{{ macros.channel_badge(transfer.to_channel, 15) }} {{ transfer.to_channel.name }}</td>
+              <th>From</th>
+              <th>To</th>
+              <th class="text-right">Amount</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in data.transfers %}
+              {% set transfer = item.transfer %}
+              <tr title="{{ item.note }}">
+                <td>{{ macros.channel_label(transfer.from_channel) }}</td>
+                <td>{{ macros.channel_label(transfer.to_channel) }}</td>
+                <td class="num">
+                  <span class="view-transfer-{{ transfer.id }}">{{ macros.peso(transfer.amount) }}</span>
+                  <div class="edit-transfer-{{ transfer.id }} hidden items-center justify-end gap-1">
+                    <span class="text-ink-soft text-sm">&#8369;</span>
+                    <input class="field field-mono w-24"
+                           type="number"
+                           step="0.01"
+                           name="amount"
+                           form="edit-transfer-form-{{ transfer.id }}"
+                           value="{{ transfer.amount }}">
+                  </div>
+                </td>
+                <td>
+                  <div class="view-transfer-{{ transfer.id }} flex items-center gap-1">
+                    <button type="button"
+                            class="icon-btn hover:bg-accent/15 hover:text-accent"
+                            onclick="toggleEditMode('transfer-{{ transfer.id }}')">Edit</button>
+                    <button class="icon-btn"
+                            hx-delete="/transfers/{{ transfer.id }}"
+                            hx-target="#cashflow-page"
+                            hx-swap="outerHTML"
+                            hx-confirm="Delete this transfer?">Delete</button>
+                  </div>
+                  <div class="edit-transfer-{{ transfer.id }} hidden items-center gap-1">
+                    <button type="submit"
+                            form="edit-transfer-form-{{ transfer.id }}"
+                            class="add-btn mt-0">Save</button>
+                    <button type="button"
+                            class="btn-secondary"
+                            onclick="cancelEdit('transfer-{{ transfer.id }}', 'edit-transfer-form-{{ transfer.id }}')">Cancel</button>
+                  </div>
+                </td>
+              </tr>
+            {% else %}
+              {{ macros.empty_row(4, 'transfers') }}
+            {% endfor %}
+            <tr>
+              <td colspan="4">
+                <button type="button"
+                        class="add-btn w-20 justify-center"
+                        onclick="toggleAddRow('add-transfer-row-{{ data.period.id }}', this)">+ Add</button>
+              </td>
+            </tr>
+            <tr id="add-transfer-row-{{ data.period.id }}" class="hidden">
+              <td>
+                <select class="field"
+                        name="from_channel_id"
+                        form="add-transfer-form-{{ data.period.id }}"
+                        required>
+                  {% for channel in channels %}
+                    <option value="{{ channel.id }}">{{ channel.name }}</option>
+                  {% endfor %}
+                </select>
+              </td>
+              <td>
+                <select class="field"
+                        name="to_channel_id"
+                        form="add-transfer-form-{{ data.period.id }}"
+                        onchange="prefillTransferAmount(this)"
+                        required>
+                  {% for channel, net in data.balances %}
+                    <option value="{{ channel.id }}"
+                            data-needed="{{ '%.2f'|format([0, -net]|max) }}">{{ channel.name }}</option>
+                  {% endfor %}
+                </select>
+              </td>
               <td class="num">
-                <span class="view-transfer-{{ transfer.id }}">{{ macros.peso(transfer.amount) }}</span>
-                <div class="edit-transfer-{{ transfer.id }} hidden items-center justify-end gap-1">
+                <div class="flex items-center justify-end gap-1">
                   <span class="text-ink-soft text-sm">&#8369;</span>
                   <input class="field field-mono w-24"
                          type="number"
                          step="0.01"
                          name="amount"
-                         form="edit-transfer-form-{{ transfer.id }}"
-                         value="{{ transfer.amount }}">
+                         form="add-transfer-form-{{ data.period.id }}"
+                         placeholder="Amount"
+                         required>
                 </div>
               </td>
               <td>
-                <div class="view-transfer-{{ transfer.id }} flex items-center gap-1">
-                  <button type="button"
-                          class="icon-btn hover:bg-accent/15 hover:text-accent"
-                          onclick="toggleEditMode('transfer-{{ transfer.id }}')">Edit</button>
-                  <button class="icon-btn"
-                          hx-delete="/transfers/{{ transfer.id }}"
-                          hx-target="#cashflow-page"
-                          hx-swap="outerHTML"
-                          hx-confirm="Delete this transfer?">Delete</button>
-                </div>
-                <div class="edit-transfer-{{ transfer.id }} hidden items-center gap-1">
-                  <button type="submit"
-                          form="edit-transfer-form-{{ transfer.id }}"
-                          class="add-btn mt-0">Save</button>
-                  <button type="button"
-                          class="btn-secondary"
-                          onclick="cancelEdit('transfer-{{ transfer.id }}', 'edit-transfer-form-{{ transfer.id }}')">Cancel</button>
-                </div>
+                <button class="add-btn"
+                        type="submit"
+                        form="add-transfer-form-{{ data.period.id }}">Add</button>
               </td>
             </tr>
-          {% else %}
-            {{ macros.empty_row(4, 'transfers') }}
-          {% endfor %}
-          <tr>
-            <td colspan="4">
-              <button type="button"
-                      class="add-btn w-20 justify-center"
-                      onclick="toggleAddRow('add-transfer-row-{{ data.period.id }}', this)">+ Add</button>
-            </td>
-          </tr>
-          <tr id="add-transfer-row-{{ data.period.id }}" class="hidden">
-            <td>
-              <select class="field"
-                      name="from_channel_id"
-                      form="add-transfer-form-{{ data.period.id }}"
-                      required>
-                {% for channel in channels %}
-                  <option value="{{ channel.id }}">{{ channel.name }}</option>
-                {% endfor %}
-              </select>
-            </td>
-            <td>
-              <select class="field"
-                      name="to_channel_id"
-                      form="add-transfer-form-{{ data.period.id }}"
-                      onchange="prefillTransferAmount(this)"
-                      required>
-                {% for channel, net in data.balances %}
-                  <option value="{{ channel.id }}"
-                          data-needed="{{ '%.2f'|format([0, -net]|max) }}">{{ channel.name }}</option>
-                {% endfor %}
-              </select>
-            </td>
-            <td class="num">
-              <div class="flex items-center justify-end gap-1">
-                <span class="text-ink-soft text-sm">&#8369;</span>
-                <input class="field field-mono w-24"
-                       type="number"
-                       step="0.01"
-                       name="amount"
-                       form="add-transfer-form-{{ data.period.id }}"
-                       placeholder="Amount"
-                       required>
-              </div>
-            </td>
-            <td>
-              <button class="add-btn"
-                      type="submit"
-                      form="add-transfer-form-{{ data.period.id }}">Add</button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <div class="mt-4 pt-3 border-t border-dashed border-paper-dim">
+          </tbody>
+        </table>
+      </div>
+      <div class="mt-4 pt-3 border-t border-dashed border-paper-dim table-wrap">
         <table class="led">
           <colgroup>
             <col>
@@ -154,7 +158,7 @@
           <tbody>
             {% for channel, net in data.balances %}
               <tr>
-                <td>{{ macros.channel_badge(channel, 15) }} {{ channel.name }}</td>
+                <td>{{ macros.channel_label(channel) }}</td>
                 <td class="num {{ 'card-value-neg' if net < 0 else '' }}">{{ macros.peso(net) }}</td>
               </tr>
             {% else %}

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -1,4 +1,4 @@
-{% import "macros.html" as macros %}
+﻿{% import "macros.html" as macros %}
 <div id="credit-page">
   <div class="page-head">
     <div>
@@ -13,172 +13,174 @@
           hx-target="#credit-page"
           hx-swap="outerHTML">
     </form>
-    <table class="led">
-      <colgroup>
-        <col>
-        <col class="w-36">
-        <col class="w-28">
-        <col class="w-28">
-        <col class="w-44">
-        <col class="w-28">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Channel</th>
-          <th class="text-right">Limit</th>
-          <th class="text-right">Used</th>
-          <th>Utilization</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in credit_lines %}
-          {% set line = item.line %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col>
+          <col class="w-40">
+          <col class="w-28">
+          <col class="w-28">
+          <col class="w-44">
+          <col class="w-28">
+        </colgroup>
+        <thead>
           <tr>
+            <th>Name</th>
+            <th>Channel</th>
+            <th class="text-right">Limit</th>
+            <th class="text-right">Used</th>
+            <th>Utilization</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in credit_lines %}
+            {% set line = item.line %}
+            <tr>
+              <td>
+                <span class="view-credit-{{ line.id }}">{{ line.name }}</span>
+                <form id="credit-edit-form-{{ line.id }}"
+                      hx-patch="/credit/{{ line.id }}"
+                      hx-target="#credit-page"
+                      hx-swap="outerHTML"
+                      class="edit-credit-{{ line.id }} hidden items-center gap-2">
+                  <input class="field" type="text" name="name" value="{{ line.name }}">
+                </form>
+              </td>
+              <td>
+                <span class="view-credit-{{ line.id }}">
+                  {% if line.channel %}
+                    {{ macros.channel_label(line.channel) }}
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </span>
+                <div class="edit-credit-{{ line.id }} hidden items-center gap-1">
+                  <select class="field" name="channel_id" form="credit-edit-form-{{ line.id }}">
+                    <option value="">No channel</option>
+                    {% for channel in channels %}
+                      <option value="{{ channel.id }}"
+                              {{ "selected" if line.channel_id == channel.id else "" }}>{{ channel.name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </td>
+              <td class="num">
+                <span class="view-credit-{{ line.id }}">{{ macros.peso(line.limit) }}</span>
+                <div class="edit-credit-{{ line.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">&#8369;</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="limit"
+                         form="credit-edit-form-{{ line.id }}"
+                         value="{{ line.limit }}">
+                </div>
+              </td>
+              <td class="num">
+                <span class="view-credit-{{ line.id }}">{{ macros.peso(line.used) }}</span>
+                <div class="edit-credit-{{ line.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">&#8369;</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="used"
+                         form="credit-edit-form-{{ line.id }}"
+                         value="{{ line.used }}">
+                </div>
+              </td>
+              <td>
+                <div class="bar-track">
+                  <div class="bar-fill" style="width: {{ [item.pct, 100]|min }}%"></div>
+                </div>
+                <div class="text-[11px] text-ink-soft mt-1 flex items-center gap-1.5">
+                  <span>{{ item.pct|round|int }}%</span>
+                  {% if item.level == "amber" %}
+                    <span class="warn-pill warn-amber">Near limit</span>
+                  {% elif item.level == "red" %}
+                    <span class="warn-pill warn-red">Over limit</span>
+                  {% endif %}
+                </div>
+              </td>
+              <td>
+                <div class="view-credit-{{ line.id }} flex items-center gap-1">
+                  <button type="button"
+                          class="icon-btn hover:bg-accent/15 hover:text-accent"
+                          onclick="toggleEditMode('credit-{{ line.id }}')">Edit</button>
+                  <button class="icon-btn"
+                          hx-delete="/credit/{{ line.id }}"
+                          hx-target="#credit-page"
+                          hx-swap="outerHTML"
+                          hx-confirm="Delete this credit line?">Delete</button>
+                </div>
+                <div class="edit-credit-{{ line.id }} hidden items-center gap-1">
+                  <button type="submit"
+                          form="credit-edit-form-{{ line.id }}"
+                          class="add-btn mt-0">Save</button>
+                  <button type="button"
+                          class="btn-secondary"
+                          onclick="cancelEdit('credit-{{ line.id }}', 'credit-edit-form-{{ line.id }}')">Cancel</button>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(6, 'credit lines') }}
+          {% endfor %}
+          <tr>
+            <td colspan="6">
+              <button type="button"
+                      class="add-btn w-20 justify-center"
+                      onclick="toggleAddRow('add-credit-row', this)">+ Add</button>
+            </td>
+          </tr>
+          <tr id="add-credit-row" class="hidden">
             <td>
-              <span class="view-credit-{{ line.id }}">{{ line.name }}</span>
-              <form id="credit-edit-form-{{ line.id }}"
-                    hx-patch="/credit/{{ line.id }}"
-                    hx-target="#credit-page"
-                    hx-swap="outerHTML"
-                    class="edit-credit-{{ line.id }} hidden items-center gap-2">
-                <input class="field" type="text" name="name" value="{{ line.name }}">
-              </form>
+              <input class="field"
+                     type="text"
+                     name="name"
+                     form="add-credit-form"
+                     placeholder="Credit line name"
+                     required>
             </td>
             <td>
-              <span class="view-credit-{{ line.id }}">
-                {% if line.channel %}
-                  {{ macros.channel_badge(line.channel, 15) }} {{ line.channel.name }}
-                {% else %}
-                  &mdash;
-                {% endif %}
-              </span>
-              <div class="edit-credit-{{ line.id }} hidden items-center gap-1">
-                <select class="field" name="channel_id" form="credit-edit-form-{{ line.id }}">
-                  <option value="">No channel</option>
-                  {% for channel in channels %}
-                    <option value="{{ channel.id }}"
-                            {{ "selected" if line.channel_id == channel.id else "" }}>{{ channel.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              </div>
+              <select class="field" name="channel_id" form="add-credit-form">
+                <option value="">No channel</option>
+                {% for channel in channels %}
+                  <option value="{{ channel.id }}">{{ channel.name }}</option>
+                {% endfor %}
+              </select>
             </td>
             <td class="num">
-              <span class="view-credit-{{ line.id }}">{{ macros.peso(line.limit) }}</span>
-              <div class="edit-credit-{{ line.id }} hidden items-center justify-end gap-1">
+              <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">&#8369;</span>
                 <input class="field field-mono w-24"
                        type="number"
                        step="0.01"
                        name="limit"
-                       form="credit-edit-form-{{ line.id }}"
-                       value="{{ line.limit }}">
+                       form="add-credit-form"
+                       placeholder="Limit"
+                       required>
               </div>
             </td>
             <td class="num">
-              <span class="view-credit-{{ line.id }}">{{ macros.peso(line.used) }}</span>
-              <div class="edit-credit-{{ line.id }} hidden items-center justify-end gap-1">
+              <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">&#8369;</span>
                 <input class="field field-mono w-24"
                        type="number"
                        step="0.01"
                        name="used"
-                       form="credit-edit-form-{{ line.id }}"
-                       value="{{ line.used }}">
+                       form="add-credit-form"
+                       placeholder="0">
               </div>
             </td>
+            <td></td>
             <td>
-              <div class="bar-track">
-                <div class="bar-fill" style="width: {{ [item.pct, 100]|min }}%"></div>
-              </div>
-              <div class="text-[11px] text-ink-soft mt-1 flex items-center gap-1.5">
-                <span>{{ item.pct|round|int }}%</span>
-                {% if item.level == "amber" %}
-                  <span class="warn-pill warn-amber">Near limit</span>
-                {% elif item.level == "red" %}
-                  <span class="warn-pill warn-red">Over limit</span>
-                {% endif %}
-              </div>
-            </td>
-            <td>
-              <div class="view-credit-{{ line.id }} flex items-center gap-1">
-                <button type="button"
-                        class="icon-btn hover:bg-accent/15 hover:text-accent"
-                        onclick="toggleEditMode('credit-{{ line.id }}')">Edit</button>
-                <button class="icon-btn"
-                        hx-delete="/credit/{{ line.id }}"
-                        hx-target="#credit-page"
-                        hx-swap="outerHTML"
-                        hx-confirm="Delete this credit line?">Delete</button>
-              </div>
-              <div class="edit-credit-{{ line.id }} hidden items-center gap-1">
-                <button type="submit"
-                        form="credit-edit-form-{{ line.id }}"
-                        class="add-btn mt-0">Save</button>
-                <button type="button"
-                        class="btn-secondary"
-                        onclick="cancelEdit('credit-{{ line.id }}', 'credit-edit-form-{{ line.id }}')">Cancel</button>
-              </div>
+              <button class="add-btn" type="submit" form="add-credit-form">Add</button>
             </td>
           </tr>
-        {% else %}
-          {{ macros.empty_row(6, 'credit lines') }}
-        {% endfor %}
-        <tr>
-          <td colspan="6">
-            <button type="button"
-                    class="add-btn w-20 justify-center"
-                    onclick="toggleAddRow('add-credit-row', this)">+ Add</button>
-          </td>
-        </tr>
-        <tr id="add-credit-row" class="hidden">
-          <td>
-            <input class="field"
-                   type="text"
-                   name="name"
-                   form="add-credit-form"
-                   placeholder="Credit line name"
-                   required>
-          </td>
-          <td>
-            <select class="field" name="channel_id" form="add-credit-form">
-              <option value="">No channel</option>
-              {% for channel in channels %}
-                <option value="{{ channel.id }}">{{ channel.name }}</option>
-              {% endfor %}
-            </select>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="limit"
-                     form="add-credit-form"
-                     placeholder="Limit"
-                     required>
-            </div>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="used"
-                     form="add-credit-form"
-                     placeholder="0">
-            </div>
-          </td>
-          <td></td>
-          <td>
-            <button class="add-btn" type="submit" form="add-credit-form">Add</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -16,7 +16,7 @@
     <div class="table-wrap">
       <table class="led">
         <colgroup>
-          <col>
+          <col class="min-w-28">
           <col class="w-40">
           <col class="w-28">
           <col class="w-28">

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -17,7 +17,7 @@
       <table class="led">
         <colgroup>
           <col class="w-12">
-          <col>
+          <col class="min-w-28">
           <col class="w-36">
           <col class="w-40">
           <col class="w-28">
@@ -182,7 +182,7 @@
         <colgroup>
           <col class="w-24">
           <col class="w-32">
-          <col>
+          <col class="min-w-28">
           <col class="w-28">
         </colgroup>
         <thead>
@@ -307,7 +307,7 @@
     <div class="table-wrap">
       <table class="led">
         <colgroup>
-          <col>
+          <col class="min-w-28">
           <col class="w-24">
           <col class="w-40">
           <col class="w-24">

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -13,124 +13,155 @@
           hx-target="#expenses-page"
           hx-swap="outerHTML">
     </form>
-    <table class="led">
-      <colgroup>
-        <col class="w-12">
-        <col>
-        <col class="w-40">
-        <col class="w-28">
-      </colgroup>
-      <thead>
-        <tr>
-          <th></th>
-          <th>Name &amp; color</th>
-          <th>Funds from</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for channel in channels %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col class="w-12">
+          <col>
+          <col class="w-36">
+          <col class="w-40">
+          <col class="w-28">
+        </colgroup>
+        <thead>
           <tr>
-            <td>{{ macros.channel_badge(channel) }}</td>
+            <th></th>
+            <th>Name &amp; color</th>
+            <th>Type</th>
+            <th>Funds from</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for channel in channels %}
+            <tr>
+              <td>{{ macros.channel_badge(channel) }}</td>
+              <td>
+                <span class="view-channel-{{ channel.id }}">{{ macros.channel_name(channel) }}</span>
+                <form id="channel-edit-form-{{ channel.id }}"
+                      hx-patch="/channels/{{ channel.id }}"
+                      hx-target="#expenses-page"
+                      hx-swap="outerHTML"
+                      class="edit-channel-{{ channel.id }} hidden items-center gap-2">
+                  <input class="field" type="text" name="name" value="{{ channel.name }}">
+                  <input class="w-10 h-8 rounded border border-line cursor-pointer"
+                         type="color"
+                         name="color"
+                         value="{{ channel.color }}">
+                </form>
+              </td>
+              <td>
+                <span class="view-channel-{{ channel.id }}">
+                  {% if channel.channel_type %}
+                    {{ channel.channel_type }}
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </span>
+                <div class="edit-channel-{{ channel.id }} hidden items-center gap-1">
+                  <select class="field"
+                          name="channel_type"
+                          form="channel-edit-form-{{ channel.id }}">
+                    <option value="">No type</option>
+                    {% for ct in channel_types %}
+                      <option value="{{ ct }}"
+                              {{ "selected" if channel.channel_type == ct else "" }}>{{ ct }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </td>
+              <td>
+                <span class="view-channel-{{ channel.id }}">
+                  {% if channel.funding_source %}
+                    {{ macros.channel_label(channel.funding_source) }}
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </span>
+                <div class="edit-channel-{{ channel.id }} hidden items-center gap-1">
+                  <select class="field"
+                          name="funding_source_channel_id"
+                          form="channel-edit-form-{{ channel.id }}">
+                    <option value="">No funding source</option>
+                    {% for c in channels if c.id != channel.id %}
+                      <option value="{{ c.id }}"
+                              {{ "selected" if channel.funding_source_channel_id == c.id else "" }}>{{ c.name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </td>
+              <td>
+                <div class="view-channel-{{ channel.id }} flex items-center gap-1">
+                  <button type="button"
+                          class="icon-btn hover:bg-accent/15 hover:text-accent"
+                          onclick="toggleEditMode('channel-{{ channel.id }}')">Edit</button>
+                  <button class="icon-btn"
+                          hx-delete="/channels/{{ channel.id }}"
+                          hx-target="#expenses-page"
+                          hx-swap="outerHTML"
+                          hx-confirm="Delete this channel?">Delete</button>
+                </div>
+                <div class="edit-channel-{{ channel.id }} hidden items-center gap-1">
+                  <button type="submit"
+                          form="channel-edit-form-{{ channel.id }}"
+                          class="add-btn mt-0">Save</button>
+                  <button type="button"
+                          class="btn-secondary"
+                          onclick="cancelEdit('channel-{{ channel.id }}', 'channel-edit-form-{{ channel.id }}')">Cancel</button>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(5, 'channels') }}
+          {% endfor %}
+          <tr>
+            <td colspan="5">
+              <button type="button"
+                      class="add-btn w-20 justify-center"
+                      onclick="toggleAddRow('add-channel-row', this)">+ Add</button>
+            </td>
+          </tr>
+          <tr id="add-channel-row" class="hidden">
+            <td></td>
             <td>
-              <span class="view-channel-{{ channel.id }}">{{ channel.name }}</span>
-              <form id="channel-edit-form-{{ channel.id }}"
-                    hx-patch="/channels/{{ channel.id }}"
-                    hx-target="#expenses-page"
-                    hx-swap="outerHTML"
-                    class="edit-channel-{{ channel.id }} hidden items-center gap-2">
-                <input class="field" type="text" name="name" value="{{ channel.name }}">
+              <div class="flex items-center gap-2">
+                <input class="field"
+                       type="text"
+                       name="name"
+                       form="add-channel-form"
+                       placeholder="Channel name"
+                       required>
                 <input class="w-10 h-8 rounded border border-line cursor-pointer"
                        type="color"
                        name="color"
-                       value="{{ channel.color }}">
-              </form>
-            </td>
-            <td>
-              <span class="view-channel-{{ channel.id }}">
-                {% if channel.funding_source %}
-                  {{ macros.channel_badge(channel.funding_source, 15) }} {{ channel.funding_source.name }}
-                {% else %}
-                  &mdash;
-                {% endif %}
-              </span>
-              <div class="edit-channel-{{ channel.id }} hidden items-center gap-1">
-                <select class="field"
-                        name="funding_source_channel_id"
-                        form="channel-edit-form-{{ channel.id }}">
-                  <option value="">No funding source</option>
-                  {% for c in channels if c.id != channel.id %}
-                    <option value="{{ c.id }}"
-                            {{ "selected" if channel.funding_source_channel_id == c.id else "" }}>{{ c.name }}
-                    </option>
-                  {% endfor %}
-                </select>
+                       form="add-channel-form"
+                       value="#8a8a8a">
               </div>
             </td>
             <td>
-              <div class="view-channel-{{ channel.id }} flex items-center gap-1">
-                <button type="button"
-                        class="icon-btn hover:bg-accent/15 hover:text-accent"
-                        onclick="toggleEditMode('channel-{{ channel.id }}')">Edit</button>
-                <button class="icon-btn"
-                        hx-delete="/channels/{{ channel.id }}"
-                        hx-target="#expenses-page"
-                        hx-swap="outerHTML"
-                        hx-confirm="Delete this channel?">Delete</button>
-              </div>
-              <div class="edit-channel-{{ channel.id }} hidden items-center gap-1">
-                <button type="submit"
-                        form="channel-edit-form-{{ channel.id }}"
-                        class="add-btn mt-0">Save</button>
-                <button type="button"
-                        class="btn-secondary"
-                        onclick="cancelEdit('channel-{{ channel.id }}', 'channel-edit-form-{{ channel.id }}')">Cancel</button>
-              </div>
+              <select class="field" name="channel_type" form="add-channel-form">
+                <option value="">No type</option>
+                {% for ct in channel_types %}<option value="{{ ct }}">{{ ct }}</option>{% endfor %}
+              </select>
+            </td>
+            <td>
+              <select class="field"
+                      name="funding_source_channel_id"
+                      form="add-channel-form">
+                <option value="">No funding source</option>
+                {% for channel in channels %}
+                  <option value="{{ channel.id }}">{{ channel.name }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td>
+              <button class="add-btn" type="submit" form="add-channel-form">Add</button>
             </td>
           </tr>
-        {% else %}
-          {{ macros.empty_row(4, 'channels') }}
-        {% endfor %}
-        <tr>
-          <td colspan="4">
-            <button type="button"
-                    class="add-btn w-20 justify-center"
-                    onclick="toggleAddRow('add-channel-row', this)">+ Add</button>
-          </td>
-        </tr>
-        <tr id="add-channel-row" class="hidden">
-          <td></td>
-          <td>
-            <div class="flex items-center gap-2">
-              <input class="field"
-                     type="text"
-                     name="name"
-                     form="add-channel-form"
-                     placeholder="Channel name"
-                     required>
-              <input class="w-10 h-8 rounded border border-line cursor-pointer"
-                     type="color"
-                     name="color"
-                     form="add-channel-form"
-                     value="#8a8a8a">
-            </div>
-          </td>
-          <td>
-            <select class="field"
-                    name="funding_source_channel_id"
-                    form="add-channel-form">
-              <option value="">No funding source</option>
-              {% for channel in channels %}
-                <option value="{{ channel.id }}">{{ channel.name }}</option>
-              {% endfor %}
-            </select>
-          </td>
-          <td>
-            <button class="add-btn" type="submit" form="add-channel-form">Add</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels }}">
     <div class="section-title">Payout periods<span class="pill">{{ payout_periods|length }} total</span></div>
@@ -146,125 +177,125 @@
             hx-swap="outerHTML">
       </form>
     {% endfor %}
-    <table class="led">
-      <colgroup>
-        <col class="w-24">
-        <col class="w-32">
-        <col>
-        <col class="w-28">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Label</th>
-          <th class="text-right">Income</th>
-          <th class="text-right">Receiving channel</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for period in payout_periods %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col class="w-24">
+          <col class="w-32">
+          <col>
+          <col class="w-28">
+        </colgroup>
+        <thead>
           <tr>
-            <td>{{ period.label }}</td>
+            <th>Label</th>
+            <th class="text-right">Income</th>
+            <th class="text-right">Receiving channel</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for period in payout_periods %}
+            <tr>
+              <td>{{ period.label }}</td>
+              <td class="num">
+                <span class="view-payout-{{ period.id }}">{{ macros.peso(period.income_amount) }}</span>
+                <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">&#8369;</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="income_amount"
+                         form="edit-payout-form-{{ period.id }}"
+                         value="{{ period.income_amount }}">
+                </div>
+              </td>
+              <td class="text-right">
+                <span class="view-payout-{{ period.id }}">
+                  {% if period.receiving_channel %}
+                    {{ macros.channel_label(period.receiving_channel) }}
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </span>
+                <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
+                  <select class="field"
+                          name="receiving_channel_id"
+                          form="edit-payout-form-{{ period.id }}">
+                    <option value="">No channel</option>
+                    {% for channel in channels %}
+                      <option value="{{ channel.id }}"
+                              {{ "selected" if period.receiving_channel_id == channel.id else "" }}>{{ channel.name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </td>
+              <td>
+                <div class="view-payout-{{ period.id }} flex items-center gap-1">
+                  <button type="button"
+                          class="icon-btn hover:bg-accent/15 hover:text-accent"
+                          onclick="toggleEditMode('payout-{{ period.id }}')">Edit</button>
+                  <button class="icon-btn"
+                          hx-delete="/payout-periods/{{ period.id }}"
+                          hx-target="#expenses-page"
+                          hx-swap="outerHTML"
+                          hx-confirm="Delete this payout period?">Delete</button>
+                </div>
+                <div class="edit-payout-{{ period.id }} hidden items-center gap-1">
+                  <button type="submit"
+                          form="edit-payout-form-{{ period.id }}"
+                          class="add-btn mt-0">Save</button>
+                  <button type="button"
+                          class="btn-secondary"
+                          onclick="cancelEdit('payout-{{ period.id }}', 'edit-payout-form-{{ period.id }}')">Cancel</button>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(4, 'payout periods') }}
+          {% endfor %}
+          <tr>
+            <td colspan="4">
+              <button type="button"
+                      class="add-btn w-20 justify-center disabled:bg-ink-soft disabled:cursor-not-allowed"
+                      {{ "disabled" if not channels }}
+                      onclick="toggleAddRow('add-payout-row', this)">+ Add
+              </button>
+            </td>
+          </tr>
+          <tr id="add-payout-row" class="hidden">
+            <td>
+              <input class="field"
+                     type="text"
+                     name="label"
+                     form="add-payout-form"
+                     placeholder="e.g. 15th"
+                     required>
+            </td>
             <td class="num">
-              <span class="view-payout-{{ period.id }}">{{ macros.peso(period.income_amount) }}</span>
-              <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
+              <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">&#8369;</span>
                 <input class="field field-mono w-24"
                        type="number"
                        step="0.01"
                        name="income_amount"
-                       form="edit-payout-form-{{ period.id }}"
-                       value="{{ period.income_amount }}">
+                       form="add-payout-form"
+                       placeholder="Income">
               </div>
             </td>
             <td class="text-right">
-              <span class="view-payout-{{ period.id }}">
-                {% if period.receiving_channel %}
-                  {{ macros.channel_badge(period.receiving_channel, 15) }} {{ period.receiving_channel.name }}
-                {% else %}
-                  &mdash;
-                {% endif %}
-              </span>
-              <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
-                <select class="field"
-                        name="receiving_channel_id"
-                        form="edit-payout-form-{{ period.id }}">
-                  <option value="">No channel</option>
-                  {% for channel in channels %}
-                    <option value="{{ channel.id }}"
-                            {{ "selected" if period.receiving_channel_id == channel.id else "" }}>{{ channel.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              </div>
+              <select class="field" name="receiving_channel_id" form="add-payout-form">
+                <option value="">No channel</option>
+                {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
+              </select>
             </td>
             <td>
-              <div class="view-payout-{{ period.id }} flex items-center gap-1">
-                <button type="button"
-                        class="icon-btn hover:bg-accent/15 hover:text-accent"
-                        onclick="toggleEditMode('payout-{{ period.id }}')">Edit</button>
-                <button class="icon-btn"
-                        hx-delete="/payout-periods/{{ period.id }}"
-                        hx-target="#expenses-page"
-                        hx-swap="outerHTML"
-                        hx-confirm="Delete this payout period?">Delete</button>
-              </div>
-              <div class="edit-payout-{{ period.id }} hidden items-center gap-1">
-                <button type="submit"
-                        form="edit-payout-form-{{ period.id }}"
-                        class="add-btn mt-0">Save</button>
-                <button type="button"
-                        class="btn-secondary"
-                        onclick="cancelEdit('payout-{{ period.id }}', 'edit-payout-form-{{ period.id }}')">Cancel</button>
-              </div>
+              <button class="add-btn" type="submit" form="add-payout-form">Add</button>
             </td>
           </tr>
-        {% else %}
-          {{ macros.empty_row(4, 'payout periods') }}
-        {% endfor %}
-        <tr>
-          <td colspan="4">
-            <button type="button"
-                    class="add-btn w-20 justify-center disabled:bg-ink-soft disabled:cursor-not-allowed"
-                    {{ "disabled" if not channels }}
-                    onclick="toggleAddRow('add-payout-row', this)">+ Add
-            </button>
-          </td>
-        </tr>
-        <tr id="add-payout-row" class="hidden">
-          <td>
-            <input class="field"
-                   type="text"
-                   name="label"
-                   form="add-payout-form"
-                   placeholder="e.g. 15th"
-                   required>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="income_amount"
-                     form="add-payout-form"
-                     placeholder="Income">
-            </div>
-          </td>
-          <td class="text-right">
-            <select class="field" name="receiving_channel_id" form="add-payout-form">
-              <option value="">No channel</option>
-              {% for channel in channels %}
-                <option value="{{ channel.id }}">{{ channel.name }}</option>
-              {% endfor %}
-            </select>
-          </td>
-          <td>
-            <button class="add-btn" type="submit" form="add-payout-form">Add</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels or not payout_periods }}">
     <div class="section-title">Recurring expenses<span class="pill">{{ expenses|length }} items</span></div>
@@ -273,93 +304,95 @@
           hx-target="#expenses-page"
           hx-swap="outerHTML">
     </form>
-    <table class="led">
-      <colgroup>
-        <col>
-        <col class="w-24">
-        <col class="w-32">
-        <col class="w-24">
-        <col class="w-20">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Payout</th>
-          <th>Channel</th>
-          <th class="text-right">Amount</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for expense in expenses %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col>
+          <col class="w-24">
+          <col class="w-40">
+          <col class="w-24">
+          <col class="w-20">
+        </colgroup>
+        <thead>
           <tr>
-            <td>{{ expense.name }}</td>
-            <td>{{ expense.payout_period.label }}</td>
-            <td>{{ macros.channel_badge(expense.channel, 15) }} {{ expense.channel.name }}</td>
-            <td class="num">{{ macros.peso(expense.amount) }}</td>
-            <td>
-              <button class="icon-btn"
-                      hx-delete="/expenses/{{ expense.id }}"
-                      hx-target="#expenses-page"
-                      hx-swap="outerHTML"
-                      hx-confirm="Delete this expense?">Delete</button>
+            <th>Name</th>
+            <th>Payout</th>
+            <th>Channel</th>
+            <th class="text-right">Amount</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for expense in expenses %}
+            <tr>
+              <td>{{ expense.name }}</td>
+              <td>{{ expense.payout_period.label }}</td>
+              <td>{{ macros.channel_label(expense.channel) }}</td>
+              <td class="num">{{ macros.peso(expense.amount) }}</td>
+              <td>
+                <button class="icon-btn"
+                        hx-delete="/expenses/{{ expense.id }}"
+                        hx-target="#expenses-page"
+                        hx-swap="outerHTML"
+                        hx-confirm="Delete this expense?">Delete</button>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(5, 'expenses') }}
+          {% endfor %}
+          <tr>
+            <td colspan="5">
+              <button type="button"
+                      class="add-btn w-20 justify-center disabled:bg-ink-soft disabled:cursor-not-allowed"
+                      {{ "disabled" if not channels or not payout_periods }}
+                      onclick="toggleAddRow('add-expense-row', this)">+ Add
+              </button>
             </td>
           </tr>
-        {% else %}
-          {{ macros.empty_row(5, 'expenses') }}
-        {% endfor %}
-        <tr>
-          <td colspan="5">
-            <button type="button"
-                    class="add-btn w-20 justify-center disabled:bg-ink-soft disabled:cursor-not-allowed"
-                    {{ "disabled" if not channels or not payout_periods }}
-                    onclick="toggleAddRow('add-expense-row', this)">+ Add
-            </button>
-          </td>
-        </tr>
-        <tr id="add-expense-row" class="hidden">
-          <td>
-            <input class="field"
-                   type="text"
-                   name="name"
-                   form="add-expense-form"
-                   placeholder="Expense name"
-                   required>
-          </td>
-          <td>
-            <select class="field"
-                    name="payout_period_id"
-                    form="add-expense-form"
-                    required>
-              {% for period in payout_periods %}
-                <option value="{{ period.id }}">{{ period.label }}</option>
-              {% endfor %}
-            </select>
-          </td>
-          <td>
-            <select class="field" name="channel_id" form="add-expense-form" required>
-              {% for channel in channels %}
-                <option value="{{ channel.id }}">{{ channel.name }}</option>
-              {% endfor %}
-            </select>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="amount"
+          <tr id="add-expense-row" class="hidden">
+            <td>
+              <input class="field"
+                     type="text"
+                     name="name"
                      form="add-expense-form"
-                     placeholder="Amount"
+                     placeholder="Expense name"
                      required>
-            </div>
-          </td>
-          <td>
-            <button class="add-btn" type="submit" form="add-expense-form">Add</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            </td>
+            <td>
+              <select class="field"
+                      name="payout_period_id"
+                      form="add-expense-form"
+                      required>
+                {% for period in payout_periods %}
+                  <option value="{{ period.id }}">{{ period.label }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td>
+              <select class="field" name="channel_id" form="add-expense-form" required>
+                {% for channel in channels %}
+                  <option value="{{ channel.id }}">{{ channel.name }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td class="num">
+              <div class="flex items-center justify-end gap-1">
+                <span class="text-ink-soft text-sm">&#8369;</span>
+                <input class="field field-mono w-24"
+                       type="number"
+                       step="0.01"
+                       name="amount"
+                       form="add-expense-form"
+                       placeholder="Amount"
+                       required>
+              </div>
+            </td>
+            <td>
+              <button class="add-btn" type="submit" form="add-expense-form">Add</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -16,7 +16,7 @@
     <div class="table-wrap">
       <table class="led">
         <colgroup>
-          <col>
+          <col class="min-w-28">
           <col class="w-40">
           <col class="w-28">
           <col class="w-28">

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -13,203 +13,207 @@
           hx-target="#goals-page"
           hx-swap="outerHTML">
     </form>
-    <table class="led">
-      <colgroup>
-        <col>
-        <col class="w-36">
-        <col class="w-28">
-        <col class="w-28">
-        <col class="w-20">
-        <col class="w-56">
-        <col class="w-28">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Channel</th>
-          <th class="text-right">Target</th>
-          <th class="text-right">Allocated</th>
-          <th class="text-right">Months</th>
-          <th>Progress</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in goals %}
-          {% set goal = item.goal %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col>
+          <col class="w-40">
+          <col class="w-28">
+          <col class="w-28">
+          <col class="w-20">
+          <col class="w-56">
+          <col class="w-28">
+        </colgroup>
+        <thead>
           <tr>
+            <th>Name</th>
+            <th>Channel</th>
+            <th class="text-right">Target</th>
+            <th class="text-right">Allocated</th>
+            <th class="text-right">Months</th>
+            <th>Progress</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in goals %}
+            {% set goal = item.goal %}
+            <tr>
+              <td>
+                <span class="view-goal-{{ goal.id }}">{{ goal.name }}</span>
+                <form id="goal-edit-form-{{ goal.id }}"
+                      hx-patch="/goals/{{ goal.id }}"
+                      hx-target="#goals-page"
+                      hx-swap="outerHTML"
+                      class="edit-goal-{{ goal.id }} hidden items-center gap-2">
+                  <input class="field" type="text" name="name" value="{{ goal.name }}">
+                </form>
+              </td>
+              <td>
+                <span class="view-goal-{{ goal.id }}">
+                  {% if goal.channel %}
+                    {{ macros.channel_label(goal.channel) }}
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </span>
+                <div class="edit-goal-{{ goal.id }} hidden items-center gap-1">
+                  <select class="field" name="channel_id" form="goal-edit-form-{{ goal.id }}">
+                    <option value="">No channel</option>
+                    {% for channel in channels %}
+                      <option value="{{ channel.id }}"
+                              {{ "selected" if goal.channel_id == channel.id else "" }}>{{ channel.name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </div>
+              </td>
+              <td class="num">
+                <span class="view-goal-{{ goal.id }}">{{ macros.peso(goal.target) }}</span>
+                <div class="edit-goal-{{ goal.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">&#8369;</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="target"
+                         form="goal-edit-form-{{ goal.id }}"
+                         value="{{ goal.target }}">
+                </div>
+              </td>
+              <td class="num">
+                <span class="view-goal-{{ goal.id }}">{{ macros.peso(goal.allocated) }}</span>
+                <div class="edit-goal-{{ goal.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">&#8369;</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="allocated"
+                         form="goal-edit-form-{{ goal.id }}"
+                         value="{{ goal.allocated }}">
+                </div>
+              </td>
+              <td class="num">
+                <span class="view-goal-{{ goal.id }}">{{ goal.months }}</span>
+                <div class="edit-goal-{{ goal.id }} hidden items-center justify-end gap-1">
+                  <input class="field field-mono w-16"
+                         type="number"
+                         step="1"
+                         min="1"
+                         name="months"
+                         form="goal-edit-form-{{ goal.id }}"
+                         value="{{ goal.months }}">
+                </div>
+              </td>
+              <td>
+                <div class="bar-track">
+                  <div class="bar-fill" style="width: {{ item.pct }}%"></div>
+                </div>
+                <div class="text-[11px] text-ink-soft mt-1">
+                  {{ item.pct|round|int }}% &middot; {{ macros.peso(item.remaining) }} left &middot; {{ macros.peso(item.monthly_needed) }}/mo &middot; {{ macros.peso(item.per_payout) }}/payout
+                </div>
+                <label class="flex items-center gap-1.5 text-[11px] text-ink-soft mt-1">
+                  <input type="checkbox"
+                         name="round_up_to_hundred"
+                         form="goal-edit-form-{{ goal.id }}"
+                         hx-patch="/goals/{{ goal.id }}"
+                         hx-include="#goal-edit-form-{{ goal.id }}, [form='goal-edit-form-{{ goal.id }}']"
+                         hx-target="#goals-page"
+                         hx-swap="outerHTML"
+                         hx-trigger="change"
+                         {{ "checked" if goal.round_up_to_hundred else "" }}>
+                  Round up to nearest &#8369;100
+                </label>
+              </td>
+              <td>
+                <div class="view-goal-{{ goal.id }} flex items-center gap-1">
+                  <button type="button"
+                          class="icon-btn hover:bg-accent/15 hover:text-accent"
+                          onclick="toggleEditMode('goal-{{ goal.id }}')">Edit</button>
+                  <button class="icon-btn"
+                          hx-delete="/goals/{{ goal.id }}"
+                          hx-target="#goals-page"
+                          hx-swap="outerHTML"
+                          hx-confirm="Delete this goal?">Delete</button>
+                </div>
+                <div class="edit-goal-{{ goal.id }} hidden items-center gap-1">
+                  <button type="submit"
+                          form="goal-edit-form-{{ goal.id }}"
+                          class="add-btn mt-0">Save</button>
+                  <button type="button"
+                          class="btn-secondary"
+                          onclick="cancelEdit('goal-{{ goal.id }}', 'goal-edit-form-{{ goal.id }}')">Cancel</button>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(7, 'goals') }}
+          {% endfor %}
+          <tr>
+            <td colspan="7">
+              <button type="button"
+                      class="add-btn w-20 justify-center"
+                      onclick="toggleAddRow('add-goal-row', this)">+ Add</button>
+            </td>
+          </tr>
+          <tr id="add-goal-row" class="hidden">
             <td>
-              <span class="view-goal-{{ goal.id }}">{{ goal.name }}</span>
-              <form id="goal-edit-form-{{ goal.id }}"
-                    hx-patch="/goals/{{ goal.id }}"
-                    hx-target="#goals-page"
-                    hx-swap="outerHTML"
-                    class="edit-goal-{{ goal.id }} hidden items-center gap-2">
-                <input class="field" type="text" name="name" value="{{ goal.name }}">
-              </form>
+              <input class="field"
+                     type="text"
+                     name="name"
+                     form="add-goal-form"
+                     placeholder="Goal name"
+                     required>
             </td>
             <td>
-              <span class="view-goal-{{ goal.id }}">
-                {% if goal.channel %}
-                  {{ macros.channel_badge(goal.channel, 15) }} {{ goal.channel.name }}
-                {% else %}
-                  &mdash;
-                {% endif %}
-              </span>
-              <div class="edit-goal-{{ goal.id }} hidden items-center gap-1">
-                <select class="field" name="channel_id" form="goal-edit-form-{{ goal.id }}">
-                  <option value="">No channel</option>
-                  {% for channel in channels %}
-                    <option value="{{ channel.id }}"
-                            {{ "selected" if goal.channel_id == channel.id else "" }}>{{ channel.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              </div>
+              <select class="field" name="channel_id" form="add-goal-form">
+                <option value="">No channel</option>
+                {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
+              </select>
             </td>
             <td class="num">
-              <span class="view-goal-{{ goal.id }}">{{ macros.peso(goal.target) }}</span>
-              <div class="edit-goal-{{ goal.id }} hidden items-center justify-end gap-1">
+              <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">&#8369;</span>
                 <input class="field field-mono w-24"
                        type="number"
                        step="0.01"
                        name="target"
-                       form="goal-edit-form-{{ goal.id }}"
-                       value="{{ goal.target }}">
+                       form="add-goal-form"
+                       placeholder="Target"
+                       required>
               </div>
             </td>
             <td class="num">
-              <span class="view-goal-{{ goal.id }}">{{ macros.peso(goal.allocated) }}</span>
-              <div class="edit-goal-{{ goal.id }} hidden items-center justify-end gap-1">
+              <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">&#8369;</span>
                 <input class="field field-mono w-24"
                        type="number"
                        step="0.01"
                        name="allocated"
-                       form="goal-edit-form-{{ goal.id }}"
-                       value="{{ goal.allocated }}">
+                       form="add-goal-form"
+                       placeholder="0">
               </div>
             </td>
             <td class="num">
-              <span class="view-goal-{{ goal.id }}">{{ goal.months }}</span>
-              <div class="edit-goal-{{ goal.id }} hidden items-center justify-end gap-1">
-                <input class="field field-mono w-16"
-                       type="number"
-                       step="1"
-                       min="1"
-                       name="months"
-                       form="goal-edit-form-{{ goal.id }}"
-                       value="{{ goal.months }}">
-              </div>
+              <input class="field field-mono w-16"
+                     type="number"
+                     step="1"
+                     min="1"
+                     name="months"
+                     form="add-goal-form"
+                     placeholder="1">
             </td>
             <td>
-              <div class="bar-track">
-                <div class="bar-fill" style="width: {{ item.pct }}%"></div>
-              </div>
-              <div class="text-[11px] text-ink-soft mt-1">
-                {{ item.pct|round|int }}% &middot; {{ macros.peso(item.remaining) }} left &middot; {{ macros.peso(item.monthly_needed) }}/mo &middot; {{ macros.peso(item.per_payout) }}/payout
-              </div>
-              <div class="view-goal-{{ goal.id }} text-[11px] text-ink-soft mt-1">
-                {% if goal.round_up_to_hundred %}Rounded up to nearest &#8369;100{% endif %}
-              </div>
-              <label class="edit-goal-{{ goal.id }} hidden items-center gap-1.5 text-[11px] text-ink-soft mt-1">
-                <input type="checkbox"
-                       name="round_up_to_hundred"
-                       form="goal-edit-form-{{ goal.id }}"
-                       {{ "checked" if goal.round_up_to_hundred else "" }}>
+              <label class="flex items-center gap-1.5 text-[11px] text-ink-soft">
+                <input type="checkbox" name="round_up_to_hundred" form="add-goal-form">
                 Round up to nearest &#8369;100
               </label>
             </td>
             <td>
-              <div class="view-goal-{{ goal.id }} flex items-center gap-1">
-                <button type="button"
-                        class="icon-btn hover:bg-accent/15 hover:text-accent"
-                        onclick="toggleEditMode('goal-{{ goal.id }}')">Edit</button>
-                <button class="icon-btn"
-                        hx-delete="/goals/{{ goal.id }}"
-                        hx-target="#goals-page"
-                        hx-swap="outerHTML"
-                        hx-confirm="Delete this goal?">Delete</button>
-              </div>
-              <div class="edit-goal-{{ goal.id }} hidden items-center gap-1">
-                <button type="submit"
-                        form="goal-edit-form-{{ goal.id }}"
-                        class="add-btn mt-0">Save</button>
-                <button type="button"
-                        class="btn-secondary"
-                        onclick="cancelEdit('goal-{{ goal.id }}', 'goal-edit-form-{{ goal.id }}')">Cancel</button>
-              </div>
+              <button class="add-btn" type="submit" form="add-goal-form">Add</button>
             </td>
           </tr>
-        {% else %}
-          {{ macros.empty_row(7, 'goals') }}
-        {% endfor %}
-        <tr>
-          <td colspan="7">
-            <button type="button"
-                    class="add-btn w-20 justify-center"
-                    onclick="toggleAddRow('add-goal-row', this)">+ Add</button>
-          </td>
-        </tr>
-        <tr id="add-goal-row" class="hidden">
-          <td>
-            <input class="field"
-                   type="text"
-                   name="name"
-                   form="add-goal-form"
-                   placeholder="Goal name"
-                   required>
-          </td>
-          <td>
-            <select class="field" name="channel_id" form="add-goal-form">
-              <option value="">No channel</option>
-              {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
-            </select>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="target"
-                     form="add-goal-form"
-                     placeholder="Target"
-                     required>
-            </div>
-          </td>
-          <td class="num">
-            <div class="flex items-center justify-end gap-1">
-              <span class="text-ink-soft text-sm">&#8369;</span>
-              <input class="field field-mono w-24"
-                     type="number"
-                     step="0.01"
-                     name="allocated"
-                     form="add-goal-form"
-                     placeholder="0">
-            </div>
-          </td>
-          <td class="num">
-            <input class="field field-mono w-16"
-                   type="number"
-                   step="1"
-                   min="1"
-                   name="months"
-                   form="add-goal-form"
-                   placeholder="1">
-          </td>
-          <td>
-            <label class="flex items-center gap-1.5 text-[11px] text-ink-soft">
-              <input type="checkbox" name="round_up_to_hundred" form="add-goal-form">
-              Round up to nearest &#8369;100
-            </label>
-          </td>
-          <td>
-            <button class="add-btn" type="submit" form="add-goal-form">Add</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -6,88 +6,92 @@
       <div class="page-sub">Net worth and progress at a glance</div>
     </div>
   </div>
-  <div class="flex gap-4 mb-5">
-    <div class="card flex-1">
+  <div class="flex flex-wrap gap-4 mb-5">
+    <div class="card flex-1 min-w-[10rem]">
       <div class="card-label">Total assets</div>
       <div class="card-value">{{ macros.peso(total_assets) }}</div>
     </div>
-    <div class="card flex-1">
+    <div class="card flex-1 min-w-[10rem]">
       <div class="card-label">Total liabilities</div>
       <div class="card-value">{{ macros.peso(total_liabilities) }}</div>
     </div>
-    <div class="card flex-1">
+    <div class="card flex-1 min-w-[10rem]">
       <div class="card-label">Net worth</div>
       <div class="card-value {{ 'card-value-neg' if net_worth < 0 else '' }}">{{ macros.peso(net_worth) }}</div>
     </div>
   </div>
   <div class="section">
     <div class="section-title">Goals<span class="pill">{{ goals|length }} total</span></div>
-    <table class="led">
-      <colgroup>
-        <col>
-        <col class="w-56">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Progress</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in goals %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col>
+          <col class="w-56">
+        </colgroup>
+        <thead>
           <tr>
-            <td>{{ item.goal.name }}</td>
-            <td>
-              <div class="bar-track">
-                <div class="bar-fill" style="width: {{ item.pct }}%"></div>
-              </div>
-              <div class="text-[11px] text-ink-soft mt-1 flex items-center gap-1.5">
-                <span>{{ item.pct|round|int }}%</span>
-                {% if item.pct >= 100 %}<span class="pill-gold">Funded</span>{% endif %}
-              </div>
-            </td>
+            <th>Name</th>
+            <th>Progress</th>
           </tr>
-        {% else %}
-          {{ macros.empty_row(2, 'goals') }}
-        {% endfor %}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {% for item in goals %}
+            <tr>
+              <td>{{ item.goal.name }}</td>
+              <td>
+                <div class="bar-track">
+                  <div class="bar-fill" style="width: {{ item.pct }}%"></div>
+                </div>
+                <div class="text-[11px] text-ink-soft mt-1 flex items-center gap-1.5">
+                  <span>{{ item.pct|round|int }}%</span>
+                  {% if item.pct >= 100 %}<span class="pill-gold">Funded</span>{% endif %}
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(2, 'goals') }}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
   <div class="section">
     <div class="section-title">Credit<span class="pill">{{ credit_lines|length }} total</span></div>
-    <table class="led">
-      <colgroup>
-        <col>
-        <col class="w-56">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Utilization</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in credit_lines %}
+    <div class="table-wrap">
+      <table class="led">
+        <colgroup>
+          <col>
+          <col class="w-56">
+        </colgroup>
+        <thead>
           <tr>
-            <td>{{ item.line.name }}</td>
-            <td>
-              <div class="bar-track">
-                <div class="bar-fill" style="width: {{ [item.pct, 100]|min }}%"></div>
-              </div>
-              <div class="text-[11px] text-ink-soft mt-1 flex items-center gap-1.5">
-                <span>{{ item.pct|round|int }}%</span>
-                {% if item.level == "amber" %}
-                  <span class="warn-pill warn-amber">Near limit</span>
-                {% elif item.level == "red" %}
-                  <span class="warn-pill warn-red">Over limit</span>
-                {% endif %}
-              </div>
-            </td>
+            <th>Name</th>
+            <th>Utilization</th>
           </tr>
-        {% else %}
-          {{ macros.empty_row(2, 'credit lines') }}
-        {% endfor %}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {% for item in credit_lines %}
+            <tr>
+              <td>{{ item.line.name }}</td>
+              <td>
+                <div class="bar-track">
+                  <div class="bar-fill" style="width: {{ [item.pct, 100]|min }}%"></div>
+                </div>
+                <div class="text-[11px] text-ink-soft mt-1 flex items-center gap-1.5">
+                  <span>{{ item.pct|round|int }}%</span>
+                  {% if item.level == "amber" %}
+                    <span class="warn-pill warn-amber">Near limit</span>
+                  {% elif item.level == "red" %}
+                    <span class="warn-pill warn-red">Over limit</span>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(2, 'credit lines') }}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -25,7 +25,7 @@
     <div class="table-wrap">
       <table class="led">
         <colgroup>
-          <col>
+          <col class="min-w-28">
           <col class="w-56">
         </colgroup>
         <thead>
@@ -60,7 +60,7 @@
     <div class="table-wrap">
       <table class="led">
         <colgroup>
-          <col>
+          <col class="min-w-28">
           <col class="w-56">
         </colgroup>
         <thead>

--- a/tests/test_cashflow.py
+++ b/tests/test_cashflow.py
@@ -9,7 +9,7 @@ def test_cashflow_page_renders(client: TestClient) -> None:
 
 
 def test_expenses_page_no_longer_shows_cash_flow(client: TestClient) -> None:
-    response = client.get("/")
+    response = client.get("/expenses")
     assert response.status_code == 200
     assert 'id="cashflow-page"' not in response.text
     assert "Generate transfers" not in response.text

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -137,4 +137,5 @@ def test_goal_round_up_toggle_reflected_on_page(client: TestClient) -> None:
         },
     )
     assert response.status_code == 200
-    assert "Rounded up to nearest" in response.text
+    assert 'name="round_up_to_hundred"' in response.text
+    assert re.search(r'name="round_up_to_hundred"[^>]*checked', response.text)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+
+def test_root_renders_overview(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'id="overview-page"' in response.text
+
+
+def test_expenses_has_its_own_route(client: TestClient) -> None:
+    response = client.get("/expenses")
+    assert response.status_code == 200
+    assert 'id="expenses-page"' in response.text
+
+
+def test_boosted_nav_request_returns_fragment_only(client: TestClient) -> None:
+    response = client.get("/goals", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    assert 'id="goals-page"' in response.text
+    assert "<html" not in response.text
+    assert "<nav" not in response.text
+
+
+def test_plain_request_returns_full_page(client: TestClient) -> None:
+    response = client.get("/goals")
+    assert response.status_code == 200
+    assert 'id="goals-page"' in response.text
+    assert "<html" in response.text
+    assert 'id="rail"' in response.text

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -188,7 +188,7 @@ def test_generate_transfers_reports_channels_without_funding_source(
 def _transfer_amount(html: str, from_name: str, to_name: str) -> str | None:
     """Find the amount cell in a transfer row rendered as From-name / To-name / amount."""
     pattern = (
-        rf"{re.escape(from_name)}</td>\s*<td>.*?{re.escape(to_name)}</td>\s*"
+        rf"{re.escape(from_name)}.*?</td>\s*<td>.*?{re.escape(to_name)}.*?</td>\s*"
         r'<td class="num">\s*<span class="view-transfer-\d+">&#8369;([\d,]+\.\d\d)</span>'
     )
     match = re.search(pattern, html, re.DOTALL)


### PR DESCRIPTION
## Summary
- Order cash flow transfers, add asset/channel types, and boosted SPA navigation
- Improve mobile usability: bigger tap targets, fix inline-form overlap

## Test plan
- [ ] `poetry run pytest`
- [ ] `poetry run ruff check .`
- [ ] `poetry run mypy app tests`
- [ ] Manually verify cash flow, assets, and mobile layouts in browser