### PR TITLE
Channel logos: PH bank/e-wallet presets and custom uploads

### DIFF
--- a/alembic/versions/e3f4a5b6c7d8_add_channel_logo.py
+++ b/alembic/versions/e3f4a5b6c7d8_add_channel_logo.py
@@ -1,0 +1,27 @@
+"""add channel logo
+
+Revision ID: e3f4a5b6c7d8
+Revises: bafc51ed3cb6
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e3f4a5b6c7d8'
+down_revision: Union[str, None] = 'bafc51ed3cb6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('channels', sa.Column('logo_data', sa.LargeBinary(), nullable=True))
+    op.add_column('channels', sa.Column('logo_mimetype', sa.String(length=50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('channels', 'logo_mimetype')
+    op.drop_column('channels', 'logo_data')

--- a/alembic/versions/f4a5b6c7d8e9_add_channel_badge_label.py
+++ b/alembic/versions/f4a5b6c7d8e9_add_channel_badge_label.py
@@ -1,0 +1,25 @@
+"""add channel badge label
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'f4a5b6c7d8e9'
+down_revision: Union[str, None] = 'e3f4a5b6c7d8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('channels', sa.Column('badge_label', sa.String(length=4), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('channels', 'badge_label')

--- a/app/crud.py
+++ b/app/crud.py
@@ -20,6 +20,41 @@ CHANNEL_TYPES: tuple[str, ...] = (
     "Cash",
 )
 
+# Quick-add presets for channels common in the Philippines. These are brand
+# colors + initials rendered through the existing badge component, not actual
+# logo artwork -- real logos are trademarked and can't be bundled here. A
+# user can still upload their own image as a channel's logo.
+_BANK = "Traditional Bank"
+_DBANK = "Digital Bank"
+_EWALLET = "E-Wallet"
+
+
+def _preset(group: str, name: str, short: str, color: str, ptype: str) -> dict[str, str]:
+    return {"group": group, "name": name, "short": short, "color": color, "type": ptype}
+
+
+CHANNEL_PRESETS: tuple[dict[str, str], ...] = (
+    _preset("Banks", "BDO", "BDO", "#003DA5", _BANK),
+    _preset("Banks", "BPI", "BPI", "#C8102E", _BANK),
+    _preset("Banks", "Metrobank", "MB", "#001B5E", _BANK),
+    _preset("Banks", "Landbank", "LB", "#00693E", _BANK),
+    _preset("Banks", "PNB", "PNB", "#7A1E1E", _BANK),
+    _preset("Banks", "China Bank", "CB", "#004990", _BANK),
+    _preset("Banks", "RCBC", "RCBC", "#0033A0", _BANK),
+    _preset("Banks", "Security Bank", "SB", "#F47920", _BANK),
+    _preset("Banks", "EastWest", "EW", "#ED1C24", _BANK),
+    _preset("Banks", "UnionBank", "UB", "#F7941E", _BANK),
+    _preset("Banks", "PSBank", "PS", "#FDB913", _BANK),
+    _preset("Digital banks & e-wallets", "GCash", "GC", "#007DFE", _EWALLET),
+    _preset("Digital banks & e-wallets", "Maya", "M", "#00D66F", _DBANK),
+    _preset("Digital banks & e-wallets", "GrabPay", "GP", "#00B14F", _EWALLET),
+    _preset("Digital banks & e-wallets", "ShopeePay", "SP", "#EE4D2D", _EWALLET),
+    _preset("Digital banks & e-wallets", "Coins.ph", "CO", "#1E5AA8", _EWALLET),
+    _preset("Digital banks & e-wallets", "SeaBank", "SB", "#EE7A0C", _DBANK),
+    _preset("Digital banks & e-wallets", "Tonik", "TN", "#7A2EBE", _DBANK),
+    _preset("Digital banks & e-wallets", "CIMB Bank PH", "CIMB", "#E4002B", _DBANK),
+)
+
 
 class ChannelInUseError(Exception):
     """Raised when deleting a channel that is still referenced elsewhere."""
@@ -90,6 +125,30 @@ def update_channel(
         channel.channel_type = data.channel_type
         db.commit()
         db.refresh(channel)
+    return channel
+
+
+def get_channel_logo(db: Session, channel_id: int, user_id: int) -> models.Channel | None:
+    return _owned(db, models.Channel, channel_id, user_id)
+
+
+def set_channel_logo(
+    db: Session, channel_id: int, data: bytes, mimetype: str, user_id: int
+) -> models.Channel | None:
+    channel = _owned(db, models.Channel, channel_id, user_id)
+    if channel is not None:
+        channel.logo_data = data
+        channel.logo_mimetype = mimetype
+        db.commit()
+    return channel
+
+
+def clear_channel_logo(db: Session, channel_id: int, user_id: int) -> models.Channel | None:
+    channel = _owned(db, models.Channel, channel_id, user_id)
+    if channel is not None:
+        channel.logo_data = None
+        channel.logo_mimetype = None
+        db.commit()
     return channel
 
 
@@ -923,10 +982,18 @@ def overview_page_data(db: Session, user_id: int) -> dict:
     }
 
 
+def channel_presets_by_group() -> dict[str, list[dict[str, str]]]:
+    groups: dict[str, list[dict[str, str]]] = {}
+    for preset in CHANNEL_PRESETS:
+        groups.setdefault(preset["group"], []).append(preset)
+    return groups
+
+
 def expenses_page_data(db: Session, user_id: int) -> dict:
     return {
         "channels": list_channels(db, user_id),
         "channel_types": CHANNEL_TYPES,
+        "channel_preset_groups": channel_presets_by_group(),
         "payout_periods": list_payout_periods(db, user_id),
         "expenses": list_expenses(db, user_id),
     }

--- a/app/crud.py
+++ b/app/crud.py
@@ -107,6 +107,7 @@ def create_channel(db: Session, data: schemas.ChannelCreate, user_id: int) -> mo
         name=data.name,
         color=data.color,
         channel_type=data.channel_type,
+        badge_label=data.badge_label,
         user_id=user_id,
     )
     db.add(channel)

--- a/app/models.py
+++ b/app/models.py
@@ -21,6 +21,7 @@ class Channel(Base):
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     color: Mapped[str] = mapped_column(String(7), default="#8a8a8a")
     channel_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    badge_label: Mapped[str | None] = mapped_column(String(4), nullable=True)
     logo_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     logo_mimetype: Mapped[str | None] = mapped_column(String(50), nullable=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey, Numeric, String, UniqueConstraint
+from sqlalchemy import ForeignKey, LargeBinary, Numeric, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -21,6 +21,8 @@ class Channel(Base):
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     color: Mapped[str] = mapped_column(String(7), default="#8a8a8a")
     channel_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    logo_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    logo_mimetype: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
 
 class PayoutPeriod(Base):

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -41,6 +41,7 @@ async def create_channel(
     name: str = Form(...),
     color: str = Form("#8a8a8a"),
     channel_type: str = Form(""),
+    badge_label: str = Form(""),
     logo: UploadFile | None = File(None),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
@@ -49,7 +50,12 @@ async def create_channel(
     try:
         channel = crud.create_channel(
             db,
-            schemas.ChannelCreate(name=name, color=color, channel_type=channel_type or None),
+            schemas.ChannelCreate(
+                name=name,
+                color=color,
+                channel_type=channel_type or None,
+                badge_label=badge_label[:4] or None,
+            ),
             current_user.id,
         )
     except crud.OwnershipError as exc:

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Response, UploadFile
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
@@ -10,6 +10,9 @@ from app.database import get_db
 router = APIRouter(prefix="/channels", tags=["channels"])
 templates = Jinja2Templates(directory="app/templates")
 
+ALLOWED_LOGO_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
+MAX_LOGO_BYTES = 300 * 1024
+
 
 def _render_page(request: Request, db: Session, user_id: int) -> HTMLResponse:
     return templates.TemplateResponse(
@@ -17,43 +20,93 @@ def _render_page(request: Request, db: Session, user_id: int) -> HTMLResponse:
     )
 
 
+async def _read_logo(logo: UploadFile | None) -> tuple[bytes, str] | None:
+    if logo is None or not logo.filename:
+        return None
+    if logo.content_type not in ALLOWED_LOGO_TYPES:
+        raise HTTPException(
+            status_code=400, detail="Logo must be a PNG, JPEG, WEBP, or GIF image."
+        )
+    data = await logo.read()
+    if not data:
+        return None
+    if len(data) > MAX_LOGO_BYTES:
+        raise HTTPException(status_code=400, detail="Logo image must be under 300KB.")
+    return data, logo.content_type
+
+
 @router.post("")
-def create_channel(
+async def create_channel(
     request: Request,
     name: str = Form(...),
     color: str = Form("#8a8a8a"),
     channel_type: str = Form(""),
+    logo: UploadFile | None = File(None),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> HTMLResponse:
+    logo_payload = await _read_logo(logo)
     try:
-        crud.create_channel(
+        channel = crud.create_channel(
             db,
             schemas.ChannelCreate(name=name, color=color, channel_type=channel_type or None),
             current_user.id,
         )
     except crud.OwnershipError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if logo_payload is not None:
+        crud.set_channel_logo(db, channel.id, logo_payload[0], logo_payload[1], current_user.id)
     return _render_page(request, db, current_user.id)
 
 
 @router.patch("/{channel_id}")
-def update_channel(
+async def update_channel(
     request: Request,
     channel_id: int,
     name: str = Form(...),
     color: str = Form(...),
     channel_type: str = Form(""),
+    logo: UploadFile | None = File(None),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> HTMLResponse:
+    logo_payload = await _read_logo(logo)
     crud.update_channel(
         db,
         channel_id,
         schemas.ChannelUpdate(name=name, color=color, channel_type=channel_type or None),
         current_user.id,
     )
+    if logo_payload is not None:
+        crud.set_channel_logo(db, channel_id, logo_payload[0], logo_payload[1], current_user.id)
     return _render_page(request, db, current_user.id)
+
+
+@router.delete("/{channel_id}/logo")
+def delete_channel_logo(
+    request: Request,
+    channel_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    crud.clear_channel_logo(db, channel_id, current_user.id)
+    return _render_page(request, db, current_user.id)
+
+
+@router.get("/{channel_id}/logo")
+def get_channel_logo(
+    channel_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    channel = crud.get_channel_logo(db, channel_id, current_user.id)
+    if channel is None or channel.logo_data is None or channel.logo_mimetype is None:
+        raise HTTPException(status_code=404, detail="No logo for this channel.")
+    return Response(
+        content=channel.logo_data,
+        media_type=channel.logo_mimetype,
+        headers={"Cache-Control": "private, max-age=300"},
+    )
 
 
 @router.post("/{channel_id}/placement")

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -24,9 +24,7 @@ async def _read_logo(logo: UploadFile | None) -> tuple[bytes, str] | None:
     if logo is None or not logo.filename:
         return None
     if logo.content_type not in ALLOWED_LOGO_TYPES:
-        raise HTTPException(
-            status_code=400, detail="Logo must be a PNG, JPEG, WEBP, or GIF image."
-        )
+        raise HTTPException(status_code=400, detail="Logo must be a PNG, JPEG, WEBP, or GIF image.")
     data = await logo.read()
     if not data:
         return None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -5,6 +5,7 @@ class ChannelCreate(BaseModel):
     name: str
     color: str = "#8a8a8a"
     channel_type: str | None = None
+    badge_label: str | None = None
 
 
 class ChannelUpdate(BaseModel):

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -132,7 +132,7 @@
   }
 
   .badge {
-    @apply inline-flex items-center justify-center rounded-full text-white text-[10px] font-bold shrink-0;
+    @apply inline-flex items-center justify-center rounded-full text-white text-[10px] font-bold shrink-0 overflow-hidden leading-none;
   }
   .badge-md {
     @apply w-[18px] h-[18px] text-[7.5px];
@@ -140,21 +140,55 @@
   .badge-sm {
     @apply w-[15px] h-[15px] text-[6.5px];
   }
+  .badge-lg {
+    @apply w-[26px] h-[26px] text-[9.5px];
+  }
 
-  .preset-picker {
-    @apply pb-3 mb-1 border-b border-line;
+  .preset-popover-wrap {
+    @apply relative;
+  }
+  .preset-trigger {
+    @apply inline-flex items-center gap-1.5 text-xs font-semibold text-ink px-3 py-1.5 rounded-lg border border-line bg-card cursor-pointer hover:border-accent transition-colors;
+  }
+  .preset-trigger svg {
+    @apply w-3 h-3 opacity-70;
+  }
+  .preset-trigger-chev {
+    @apply w-2 h-2 transition-transform duration-150;
+  }
+  .preset-trigger-open .preset-trigger-chev {
+    @apply rotate-180;
+  }
+  .preset-popover {
+    @apply absolute left-0 top-full mt-2 z-20 w-80 max-h-80 overflow-y-auto bg-card border border-line rounded-xl shadow-lg p-3;
+    animation: preset-popover-in 0.14s cubic-bezier(0.2, 0.9, 0.3, 1);
+  }
+  @keyframes preset-popover-in {
+    from {
+      opacity: 0;
+      transform: scale(0.97) translateY(-3px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .preset-popover {
+      animation: none;
+    }
   }
   .preset-group-label {
-    @apply text-[10.5px] uppercase tracking-wide text-ink-soft font-semibold mt-2.5 mb-1.5 first:mt-0;
+    @apply text-[10px] uppercase tracking-wide text-ink-soft font-bold mt-2.5 mb-1.5 mx-0.5 first:mt-0;
   }
   .preset-grid {
-    @apply flex flex-wrap gap-1.5;
+    @apply grid grid-cols-3 gap-1.5;
   }
-  .preset-chip {
-    @apply inline-flex items-center gap-1.5 bg-paper-dim border border-transparent rounded-full pl-1 pr-2.5 py-1 text-xs font-medium text-ink cursor-pointer hover:border-accent transition-colors;
+  .preset-tile {
+    @apply flex flex-col items-center gap-1.5 bg-paper-dim border border-transparent rounded-lg px-1 py-2.5 cursor-pointer hover:border-accent hover:bg-accent/10 hover:-translate-y-px transition-all;
   }
-  .preset-chip-selected {
-    @apply border-accent bg-accent/10;
+  .preset-tile-name {
+    @apply text-[10.5px] font-semibold text-ink text-center leading-tight truncate max-w-full;
   }
 
   .bar-track {

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -141,6 +141,22 @@
     @apply w-[15px] h-[15px] text-[6.5px];
   }
 
+  .preset-picker {
+    @apply pb-3 mb-1 border-b border-line;
+  }
+  .preset-group-label {
+    @apply text-[10.5px] uppercase tracking-wide text-ink-soft font-semibold mt-2.5 mb-1.5 first:mt-0;
+  }
+  .preset-grid {
+    @apply flex flex-wrap gap-1.5;
+  }
+  .preset-chip {
+    @apply inline-flex items-center gap-1.5 bg-paper-dim border border-transparent rounded-full pl-1 pr-2.5 py-1 text-xs font-medium text-ink cursor-pointer hover:border-accent transition-colors;
+  }
+  .preset-chip-selected {
+    @apply border-accent bg-accent/10;
+  }
+
   .bar-track {
     @apply h-2 bg-paper-dim rounded-full overflow-hidden;
   }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -207,6 +207,15 @@
         }
       }
 
+      function applyChannelPreset(name, color, channelType, chipEl) {
+        const row = chipEl.closest("#add-channel-row");
+        row.querySelectorAll(".preset-chip").forEach((c) => c.classList.remove("preset-chip-selected"));
+        chipEl.classList.add("preset-chip-selected");
+        row.querySelector('[name="name"]').value = name;
+        row.querySelector('[name="color"]').value = color;
+        row.querySelector('[name="channel_type"]').value = channelType;
+      }
+
       function prefillTransferAmount(selectEl) {
         const opt = selectEl.selectedOptions[0];
         if (!opt || !opt.dataset.needed) return;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -200,20 +200,51 @@
       function toggleAddRow(rowId, buttonEl) {
         const row = document.getElementById(rowId);
         row.classList.toggle("hidden");
+        const visible = !row.classList.contains("hidden");
+        // Rows outside a <table> (e.g. add-channel-row) need "flex" toggled
+        // alongside "hidden" -- a bare <tr> restores its table-row display
+        // on its own, but a <div> would otherwise default to block.
+        if (row.tagName !== "TR") row.classList.toggle("flex", visible);
         buttonEl.textContent = row.classList.contains("hidden") ? "+ Add" : "Cancel";
-        if (!row.classList.contains("hidden")) {
+        if (visible) {
           const toSelect = row.querySelector('select[name="to_channel_id"]');
           if (toSelect) prefillTransferAmount(toSelect);
         }
       }
 
-      function applyChannelPreset(name, color, channelType, chipEl) {
-        const row = chipEl.closest("#add-channel-row");
-        row.querySelectorAll(".preset-chip").forEach((c) => c.classList.remove("preset-chip-selected"));
-        chipEl.classList.add("preset-chip-selected");
+      function closeAllPresetPopovers() {
+        document.querySelectorAll(".preset-popover").forEach((p) => p.classList.add("hidden"));
+        document
+          .querySelectorAll(".preset-trigger")
+          .forEach((t) => t.classList.remove("preset-trigger-open"));
+      }
+
+      function togglePresetPopover(buttonEl) {
+        const popover = buttonEl.nextElementSibling;
+        const wasHidden = popover.classList.contains("hidden");
+        closeAllPresetPopovers();
+        if (wasHidden) {
+          popover.classList.remove("hidden");
+          buttonEl.classList.add("preset-trigger-open");
+        }
+      }
+
+      document.addEventListener("click", (evt) => {
+        if (evt.target.closest(".preset-popover-wrap")) return;
+        closeAllPresetPopovers();
+      });
+
+      document.addEventListener("keydown", (evt) => {
+        if (evt.key === "Escape") closeAllPresetPopovers();
+      });
+
+      function applyChannelPreset(name, color, channelType, badgeLabel, itemEl) {
+        const row = itemEl.closest("#add-channel-row");
         row.querySelector('[name="name"]').value = name;
         row.querySelector('[name="color"]').value = color;
         row.querySelector('[name="channel_type"]').value = channelType;
+        row.querySelector('[name="badge_label"]').value = badgeLabel;
+        closeAllPresetPopovers();
       }
 
       function prefillTransferAmount(selectEl) {

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -1,8 +1,14 @@
 {% macro channel_badge(channel, size=18) %}
-  {% set words = channel.name.split() %}
-  {% set initials = (words[0][0] ~ (words[1][0] if words|length > 1 else "")) | upper %}
-  <span class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }}"
-        style="background: {{ channel.color }}">{{ initials }}</span>
+  {% if channel.logo_data %}
+    <img class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }} object-cover"
+         src="/channels/{{ channel.id }}/logo"
+         alt="{{ channel.name }} logo">
+  {% else %}
+    {% set words = channel.name.split() %}
+    {% set initials = (words[0][0] ~ (words[1][0] if words|length > 1 else "")) | upper %}
+    <span class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }}"
+          style="background: {{ channel.color }}">{{ initials }}</span>
+  {% endif %}
 {% endmacro %}
 {% macro channel_name(channel, max_len=18) %}
   <span title="{{ channel.name }}">{{ channel.name|truncate(max_len, True, '…') }}</span>

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -3,6 +3,9 @@
     <img class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }} object-cover"
          src="/channels/{{ channel.id }}/logo"
          alt="{{ channel.name }} logo">
+  {% elif channel.badge_label %}
+    <span class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }}"
+          style="background: {{ channel.color }}">{{ channel.badge_label }}</span>
   {% else %}
     {% set words = channel.name.split() %}
     {% set initials = (words[0][0] ~ (words[1][0] if words|length > 1 else "")) | upper %}

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -106,58 +106,75 @@
           {% else %}
             {{ macros.empty_row(4, 'channels') }}
           {% endfor %}
-          <tr>
-            <td colspan="4">
-              <button type="button"
-                      class="add-btn w-20 justify-center"
-                      onclick="toggleAddRow('add-channel-row', this)">+ Add</button>
-            </td>
-          </tr>
-          <tr id="add-channel-row" class="hidden">
-            <td colspan="4">
-              <div class="preset-picker">
-                {% for group, presets in channel_preset_groups.items() %}
-                  <div class="preset-group-label">{{ group }}</div>
-                  <div class="preset-grid">
-                    {% for preset in presets %}
-                      <button type="button"
-                              class="preset-chip"
-                              onclick="applyChannelPreset('{{ preset.name }}', '{{ preset.color }}', '{{ preset.type }}', this)">
-                        <span class="badge badge-sm" style="background: {{ preset.color }}">{{ preset.short }}</span>
-                        {{ preset.name }}
-                      </button>
-                    {% endfor %}
-                  </div>
-                {% endfor %}
-              </div>
-              <div class="flex items-center gap-2 flex-wrap mt-3">
-                <input class="field"
-                       type="text"
-                       name="name"
-                       form="add-channel-form"
-                       placeholder="Channel name"
-                       required>
-                <input class="w-10 h-8 rounded border border-line cursor-pointer"
-                       type="color"
-                       name="color"
-                       form="add-channel-form"
-                       value="#8a8a8a">
-                <select class="field" name="channel_type" form="add-channel-form">
-                  <option value="">No type</option>
-                  {% for ct in channel_types %}<option value="{{ ct }}">{{ ct }}</option>{% endfor %}
-                </select>
-                <input class="field text-xs"
-                       type="file"
-                       name="logo"
-                       form="add-channel-form"
-                       accept="image/png,image/jpeg,image/webp,image/gif"
-                       title="Optional custom logo image (overrides the preset badge)">
-                <button class="add-btn" type="submit" form="add-channel-form">Add</button>
-              </div>
-            </td>
-          </tr>
         </tbody>
       </table>
+    </div>
+    <button type="button"
+            class="add-btn w-20 justify-center"
+            onclick="toggleAddRow('add-channel-row', this)">+ Add</button>
+    <div id="add-channel-row" class="hidden items-center gap-2 flex-wrap mt-3">
+      <div class="preset-popover-wrap">
+        <button type="button"
+                class="preset-trigger"
+                onclick="togglePresetPopover(this)">
+          <svg viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="2">
+            <rect x="3" y="3" width="7" height="7" rx="1.5"></rect>
+            <rect x="14" y="3" width="7" height="7" rx="1.5"></rect>
+            <rect x="3" y="14" width="7" height="7" rx="1.5"></rect>
+            <rect x="14" y="14" width="7" height="7" rx="1.5"></rect>
+          </svg>
+          Presets
+          <svg class="preset-trigger-chev"
+               viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="3">
+            <path d="M6 9l6 6 6-6"></path>
+          </svg>
+        </button>
+        <div class="preset-popover hidden">
+          {% for group, presets in channel_preset_groups.items() %}
+            <div class="preset-group-label">{{ group }}</div>
+            <div class="preset-grid">
+              {% for preset in presets %}
+                <button type="button"
+                        class="preset-tile"
+                        onclick="applyChannelPreset('{{ preset.name }}', '{{ preset.color }}', '{{ preset.type }}', '{{ preset.short }}', this)">
+                  <span class="badge badge-lg" style="background: {{ preset.color }}">{{ preset.short }}</span>
+                  <span class="preset-tile-name">{{ preset.name }}</span>
+                </button>
+              {% endfor %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+      <input class="field flex-1 min-w-[140px]"
+             type="text"
+             name="name"
+             form="add-channel-form"
+             placeholder="Channel name"
+             oninput="this.form.elements.badge_label.value = ''"
+             required>
+      <input class="w-10 h-8 rounded border border-line cursor-pointer"
+             type="color"
+             name="color"
+             form="add-channel-form"
+             value="#8a8a8a">
+      <select class="field w-40" name="channel_type" form="add-channel-form">
+        <option value="">No type</option>
+        {% for ct in channel_types %}<option value="{{ ct }}">{{ ct }}</option>{% endfor %}
+      </select>
+      <input class="field w-48 text-xs"
+             type="file"
+             name="logo"
+             form="add-channel-form"
+             accept="image/png,image/jpeg,image/webp,image/gif"
+             title="Optional custom logo image (overrides the preset badge)">
+      <input type="hidden" name="badge_label" form="add-channel-form">
+      <button class="add-btn" type="submit" form="add-channel-form">Add</button>
     </div>
   </div>
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels }}">

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -11,7 +11,8 @@
     <form id="add-channel-form"
           hx-post="/channels"
           hx-target="#expenses-page"
-          hx-swap="outerHTML">
+          hx-swap="outerHTML"
+          hx-encoding="multipart/form-data">
     </form>
     <div class="table-wrap">
       <table class="led">
@@ -39,12 +40,25 @@
                       hx-patch="/channels/{{ channel.id }}"
                       hx-target="#expenses-page"
                       hx-swap="outerHTML"
-                      class="edit-channel-{{ channel.id }} hidden items-center gap-2">
+                      hx-encoding="multipart/form-data"
+                      class="edit-channel-{{ channel.id }} hidden items-center gap-2 flex-wrap">
                   <input class="field" type="text" name="name" value="{{ channel.name }}">
                   <input class="w-10 h-8 rounded border border-line cursor-pointer"
                          type="color"
                          name="color"
                          value="{{ channel.color }}">
+                  <input class="field text-xs"
+                         type="file"
+                         name="logo"
+                         accept="image/png,image/jpeg,image/webp,image/gif">
+                  {% if channel.logo_data %}
+                    <button type="button"
+                            class="icon-btn hover:bg-rust-soft hover:text-rust"
+                            hx-delete="/channels/{{ channel.id }}/logo"
+                            hx-target="#expenses-page"
+                            hx-swap="outerHTML"
+                            hx-confirm="Remove this channel's uploaded logo?">Remove logo</button>
+                  {% endif %}
                 </form>
               </td>
               <td>
@@ -100,9 +114,23 @@
             </td>
           </tr>
           <tr id="add-channel-row" class="hidden">
-            <td></td>
-            <td>
-              <div class="flex items-center gap-2">
+            <td colspan="4">
+              <div class="preset-picker">
+                {% for group, presets in channel_preset_groups.items() %}
+                  <div class="preset-group-label">{{ group }}</div>
+                  <div class="preset-grid">
+                    {% for preset in presets %}
+                      <button type="button"
+                              class="preset-chip"
+                              onclick="applyChannelPreset('{{ preset.name }}', '{{ preset.color }}', '{{ preset.type }}', this)">
+                        <span class="badge badge-sm" style="background: {{ preset.color }}">{{ preset.short }}</span>
+                        {{ preset.name }}
+                      </button>
+                    {% endfor %}
+                  </div>
+                {% endfor %}
+              </div>
+              <div class="flex items-center gap-2 flex-wrap mt-3">
                 <input class="field"
                        type="text"
                        name="name"
@@ -114,16 +142,18 @@
                        name="color"
                        form="add-channel-form"
                        value="#8a8a8a">
+                <select class="field" name="channel_type" form="add-channel-form">
+                  <option value="">No type</option>
+                  {% for ct in channel_types %}<option value="{{ ct }}">{{ ct }}</option>{% endfor %}
+                </select>
+                <input class="field text-xs"
+                       type="file"
+                       name="logo"
+                       form="add-channel-form"
+                       accept="image/png,image/jpeg,image/webp,image/gif"
+                       title="Optional custom logo image (overrides the preset badge)">
+                <button class="add-btn" type="submit" form="add-channel-form">Add</button>
               </div>
-            </td>
-            <td>
-              <select class="field" name="channel_type" form="add-channel-form">
-                <option value="">No type</option>
-                {% for ct in channel_types %}<option value="{{ ct }}">{{ ct }}</option>{% endfor %}
-              </select>
-            </td>
-            <td>
-              <button class="add-btn" type="submit" form="add-channel-form">Add</button>
             </td>
           </tr>
         </tbody>
@@ -337,9 +367,7 @@
             </td>
             <td>
               <select class="field" name="channel_id" form="add-expense-form" required>
-                {% for channel in channels %}
-                  <option value="{{ channel.id }}">{{ channel.name }}</option>
-                {% endfor %}
+                {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
               </select>
             </td>
             <td class="num">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finance-tracker"
-version = "1.4.0"
+version = "1.5.0"
 description = "Personal finance tracker (FastAPI + HTMX + Postgres)"
 requires-python = ">=3.12,<4.0"
 dependencies = [
@@ -40,7 +40,7 @@ extend-exclude = ["alembic/versions"]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.ruff.lint.flake8-bugbear]
-extend-immutable-calls = ["fastapi.Depends", "fastapi.Form"]
+extend-immutable-calls = ["fastapi.Depends", "fastapi.Form", "fastapi.File"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -104,6 +104,67 @@ def test_channel_starts_unplaced_and_can_be_placed_then_repositioned(
     assert 'data-y="45.0"' in page.text
 
 
+def test_channel_presets_render_on_expenses_page(client: TestClient) -> None:
+    response = client.get("/expenses")
+    assert response.status_code == 200
+    assert "GCash" in response.text
+    assert "BDO" in response.text
+    assert "applyChannelPreset(" in response.text
+
+
+def _png_bytes() -> bytes:
+    # Smallest valid 1x1 transparent PNG.
+    return bytes.fromhex(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+        "0000000a49444154789c6360000002000100ffff03000006000557bfabd4000000"
+        "0049454e44ae426082"
+    )
+
+
+def test_upload_channel_logo_is_served_and_replaces_badge_initials(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Custom Wallet")
+
+    upload = client.patch(
+        f"/channels/{channel_id}",
+        data={"name": "Custom Wallet", "color": "#8a8a8a"},
+        files={"logo": ("logo.png", _png_bytes(), "image/png")},
+    )
+    assert upload.status_code == 200
+    assert f'src="/channels/{channel_id}/logo"' in upload.text
+
+    logo = client.get(f"/channels/{channel_id}/logo")
+    assert logo.status_code == 200
+    assert logo.headers["content-type"] == "image/png"
+    assert logo.content == _png_bytes()
+
+
+def test_upload_channel_logo_rejects_non_image_files(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Custom Wallet")
+
+    upload = client.patch(
+        f"/channels/{channel_id}",
+        data={"name": "Custom Wallet", "color": "#8a8a8a"},
+        files={"logo": ("evil.txt", b"not an image", "text/plain")},
+    )
+    assert upload.status_code == 400
+
+
+def test_remove_channel_logo_falls_back_to_initials(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Custom Wallet")
+    client.patch(
+        f"/channels/{channel_id}",
+        data={"name": "Custom Wallet", "color": "#8a8a8a"},
+        files={"logo": ("logo.png", _png_bytes(), "image/png")},
+    )
+
+    removed = client.delete(f"/channels/{channel_id}/logo")
+    assert removed.status_code == 200
+    assert f'src="/channels/{channel_id}/logo"' not in removed.text
+
+    logo = client.get(f"/channels/{channel_id}/logo")
+    assert logo.status_code == 404
+
+
 def test_remove_channel_placement_returns_it_to_the_toolbox(client: TestClient) -> None:
     channel_id = _create_channel(client, "BPI")
     period_id = _create_payout_period(client, channel_id)


### PR DESCRIPTION
## Summary
- Adds channel "logos": a curated preset picker for common PH banks/e-wallets (BDO, BPI, GCash, Maya, GrabPay, etc.) using each institution's real brand color as a colored-initials badge — no bundled logo image files, since those are trademarked.
- Adds custom logo image upload per channel (PNG/JPEG/WEBP/GIF, 300KB cap), stored as bytes in Postgres (not local disk, since the Vercel deploy's filesystem isn't persistent) and served via `GET /channels/{id}/logo`.
- Preset picker is a "Presets" popover with a logo-tile grid grouped by Banks / Digital banks & e-wallets, rather than an always-open flat list.
- Fixes two layout bugs hit during review: the add-channel row rendering vertically instead of horizontally (a `.field`'s `width:100%` was forcing every sibling field onto its own flex line), and the whole channels table becoming horizontally scrollable when the popover was open (it was cramped inside a `table-fixed` colspan cell).
- Fixes channel badges not matching the preset they were created from (name-derived initials diverged from the preset's actual short label, e.g. GCash showed "G" instead of "GC") by persisting the preset's short label (`badge_label`) on the channel.

## Test plan
- [x] `ruff check .`, `ruff format --check .`
- [x] `mypy app tests`
- [x] `djlint app/templates --profile jinja --check`
- [x] `pytest` (83 passed, including new coverage for presets rendering and logo upload/serve/remove/reject-non-image)
- [x] Migrations applied against the local dev DB (`alembic upgrade head`)
- [x] Manually exercised the full flow against the running dev server (preset selection, custom upload, logo serving, logo removal, horizontal layout, no table scroll)