### PR TITLE
(chore) Move version bumps to release time only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,21 @@ jobs:
           fi
 
   version-check:
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'dev'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Ensure pyproject.toml version was bumped
+      - name: Ensure pyproject.toml version was bumped for release
         run: |
-          git fetch origin dev --depth=1
-          base_version=$(git show origin/dev:pyproject.toml | grep -m1 '^version = ' | cut -d'"' -f2)
+          git fetch origin main --depth=1
+          base_version=$(git show origin/main:pyproject.toml | grep -m1 '^version = ' | cut -d'"' -f2)
           head_version=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
-          echo "dev=$base_version, this PR=$head_version"
+          echo "main=$base_version, this release=$head_version"
           if [ "$base_version" = "$head_version" ]; then
-            echo "::error::pyproject.toml's [project].version ($head_version) wasn't bumped. Bump it following SemVer before merging into dev (see CLAUDE.md's Versioning section)."
+            echo "::error::pyproject.toml's [project].version ($head_version) wasn't bumped. Bump it following SemVer before releasing to main (see CLAUDE.md's Versioning section)."
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,9 @@ Modeled after a personal "ledger" budgeting workflow (income arrives on recurrin
 
 ## Versioning
 
-`pyproject.toml`'s `[project].version` is the source of truth, following SemVer (`MAJOR.MINOR.PATCH`). Every PR into `dev` must bump it — the `version-check` job in `.github/workflows/ci.yml` fails the PR if it's unchanged from `dev`'s current value. Bump level follows the commit-type tags already used in this repo's commit messages (see "Commit messages" above):
-- Any `(feat)` commit in the PR → bump minor, reset patch to 0 (e.g. `1.1.0` → `1.2.0`)
+`pyproject.toml`'s `[project].version` is the source of truth, following SemVer (`MAJOR.MINOR.PATCH`). The version bumps **only on the release PR from `dev` into `main`** — feature branches merging into `dev` don't touch it, so `dev` can absorb any number of merged features without implying a release happened. The `version-check` job in `.github/workflows/ci.yml` enforces this: it fails a PR targeting `main` if the version is unchanged from `main`'s current value (PRs into `dev` are exempt from this check). Bump level follows the commit-type tags already used in this repo's commit messages (see "Commit messages" above), applied to the aggregate of commits being released since the last release:
+- Any `(feat)` commit since the last release → bump minor, reset patch to 0 (e.g. `1.1.0` → `1.2.0`)
 - Only `(fix)`/`(chore)` commits → bump patch (e.g. `1.1.0` → `1.1.1`)
 - A breaking change → bump major, reset minor/patch to 0 (e.g. `1.1.0` → `2.0.0`); call it out explicitly in the commit body since there's no dedicated marker convention yet
 
-When `dev` is later merged into `main` as a release, tag `main` with a matching `vX.Y.Z` git tag (e.g. `v1.0.0` — the existing precedent) — done manually at release time, not automated.
+Pre-release, the app is versioned `0.x.y`; the first real production release is what bumps it to `1.0.0`. At release time (the `dev` → `main` PR that ships it), also tag `main` with a matching `vX.Y.Z` git tag (e.g. `v1.0.0`) — done manually, not automated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finance-tracker"
-version = "1.5.2"
+version = "0.1.0"
 description = "Personal finance tracker (FastAPI + HTMX + Postgres)"
 requires-python = ">=3.12,<4.0"
 dependencies = [


### PR DESCRIPTION
## Summary
- Version bumps now happen only on the release PR from `dev` into `main`, not on every feature branch merge into `dev`.
- Resets `pyproject.toml` to `0.1.0` — the app hasn't actually shipped yet, but `dev` had climbed to `1.5.2` purely from per-PR bumps with nothing released.
- `version-check` CI job now checks PRs targeting `main` against `main`'s version, instead of PRs targeting `dev` against `dev`'s version.
- Updates the Versioning section of CLAUDE.md accordingly.

## Test plan
- [ ] CI passes (lint-and-test, enforce-branch-source, version-check skips since this targets dev)