### PR TITLE
(feat) Add unauthenticated GET /health endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 import os
 
 from fastapi import Depends, FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -63,6 +65,15 @@ app.include_router(overview.router)
 app.include_router(cashflow.router)
 
 PLACEHOLDER_SECTIONS: dict[str, str] = {}
+
+
+@app.get("/health")
+def health(db: Session = Depends(get_db)) -> JSONResponse:
+    try:
+        db.execute(text("SELECT 1"))
+    except SQLAlchemyError:
+        return JSONResponse({"status": "error"}, status_code=503)
+    return JSONResponse({"status": "ok"})
 
 
 @app.get("/")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+
+def test_health_ok(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_health_requires_no_auth(client: TestClient) -> None:
+    client.cookies.clear()
+    response = client.get("/health", follow_redirects=False)
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Adds `GET /health` (excluded from the `get_current_user` auth dependency) so external uptime monitors have something safe to poll — every other route requires real session credentials, so today they can only hit `/login`, which doesn't verify DB connectivity.
- Runs a cheap `SELECT 1` against the DB via the existing `get_db` dependency; returns `{"status": "ok"}` (200) on success or `{"status": "error"}` (503) if the query raises `SQLAlchemyError`.
- Registered ahead of the `/{section}` placeholder catch-all in `app/main.py`, same pattern as `/`.

Closes #20.

## Test plan
- [x] `poetry run ruff check .` / `ruff format .`
- [x] `poetry run python -m mypy app tests`
- [x] `poetry run python -m djlint app/templates --profile jinja --check`
- [x] `poetry run python -m pytest` (103 passed) — added `tests/test_health.py` covering a 200/ok response and that the route needs no auth cookie