### PR TITLE
(feat) Add name filter to the Expenses list

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -312,10 +312,12 @@ def delete_payout_period(db: Session, payout_period_id: int, user_id: int) -> No
 # --- Expenses -----------------------------------------------------------------
 
 
-def list_expenses(db: Session, user_id: int) -> list[models.Expense]:
+def list_expenses(db: Session, user_id: int, q: str | None = None) -> list[models.Expense]:
     stmt = (
         select(models.Expense).where(models.Expense.user_id == user_id).order_by(models.Expense.id)
     )
+    if q:
+        stmt = stmt.where(models.Expense.name.ilike(f"%{q}%"))
     return list(db.scalars(stmt))
 
 
@@ -1007,13 +1009,14 @@ def channel_presets_by_group() -> dict[str, list[dict[str, str]]]:
     return groups
 
 
-def expenses_page_data(db: Session, user_id: int) -> dict:
+def expenses_page_data(db: Session, user_id: int, q: str | None = None) -> dict:
     return {
         "channels": list_channels(db, user_id),
         "channel_types": CHANNEL_TYPES,
         "channel_preset_groups": channel_presets_by_group(),
         "payout_periods": list_payout_periods(db, user_id),
-        "expenses": list_expenses(db, user_id),
+        "expenses": list_expenses(db, user_id, q),
+        "q": q or "",
     }
 
 

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -20,6 +20,7 @@ def _render_page(request: Request, db: Session, user_id: int) -> HTMLResponse:
 @router.get("")
 def index(
     request: Request,
+    q: str = "",
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> HTMLResponse:
@@ -27,7 +28,7 @@ def index(
         "partials/expenses_page.html" if request.headers.get("HX-Request") else "expenses.html"
     )
     return templates.TemplateResponse(
-        request, template, crud.expenses_page_data(db, current_user.id)
+        request, template, crud.expenses_page_data(db, current_user.id, q)
     )
 
 

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -312,7 +312,20 @@
     </div>
   </div>
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels or not payout_periods }}">
-    <div class="section-title">Recurring expenses<span class="pill">{{ expenses|length }} items</span></div>
+    <div class="section-title">
+      <span>Recurring expenses<span class="pill">{{ expenses|length }} items</span></span>
+      <input id="expense-search"
+             class="field w-48"
+             type="search"
+             name="q"
+             value="{{ q }}"
+             placeholder="Filter by name&hellip;"
+             hx-preserve
+             hx-get="/expenses"
+             hx-trigger="keyup changed delay:300ms, search"
+             hx-target="#expenses-page"
+             hx-swap="outerHTML">
+    </div>
     <form id="add-expense-form"
           hx-post="/expenses"
           hx-target="#expenses-page"

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -44,3 +44,39 @@ def test_create_and_delete_expense(client: TestClient) -> None:
     response = client.delete(f"/expenses/{expense_id}")
     assert response.status_code == 200
     assert "Groceries" not in response.text
+
+
+def test_expenses_filter_by_name(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", channel_id)
+    client.post(
+        "/expenses",
+        data={
+            "name": "Groceries",
+            "amount": "150.75",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+    client.post(
+        "/expenses",
+        data={
+            "name": "Electricity",
+            "amount": "800",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+
+    unfiltered = client.get("/expenses", headers={"HX-Request": "true"})
+    assert "Groceries" in unfiltered.text
+    assert "Electricity" in unfiltered.text
+
+    filtered = client.get("/expenses", params={"q": "groc"}, headers={"HX-Request": "true"})
+    assert "Groceries" in filtered.text
+    assert "Electricity" not in filtered.text
+
+    no_match = client.get("/expenses", params={"q": "nonexistent"}, headers={"HX-Request": "true"})
+    assert "Groceries" not in no_match.text
+    assert "Electricity" not in no_match.text
+    assert "0 items" in no_match.text


### PR DESCRIPTION
## Summary
- Closes #23.
- \`crud.list_expenses()\`/\`expenses_page_data()\` take an optional \`q\` param, filtering expenses by a case-insensitive substring match on \`name\` (via SQLAlchemy's \`.ilike()\`, which compiles to backend-appropriate SQL on both Postgres and SQLite).
- \`GET /expenses\` accepts a \`q\` query param and passes it through; the Recurring expenses section header gets a search input (\`hx-get=\"/expenses\"\`, \`hx-trigger=\"keyup changed delay:300ms, search\"\`, \`hx-target=\"#expenses-page\"\`) fitting the existing whole-page-render contract rather than introducing a new swap target.
- The input uses \`hx-preserve\` so it survives the full \`#expenses-page\` outerHTML swap as the same DOM node — keeps focus/cursor position while typing instead of losing it on every keystroke-triggered re-render.
- Mutating routes (create/delete expense) are unaffected — they keep re-rendering the unfiltered page via the existing \`_render_page()\` helper, per the issue's "not urgent, flagging for later" framing; filtering only applies to the explicit \`GET /expenses\` search.

## Test plan
- [x] \`poetry run pytest\` (102 passed), including a new \`test_expenses_filter_by_name\` covering unfiltered/filtered/no-match cases
- [x] \`poetry run ruff check .\` / \`ruff format --check .\`
- [x] \`poetry run mypy app tests\`
- [x] \`poetry run djlint app/templates --profile jinja --check\`