### PR TITLE
(fix) Add viewport meta tag for mobile rendering

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
     <title>Finance Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Log in — Finance Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"


### PR DESCRIPTION
## Summary
Closes #26.

Audited the app at phone viewport widths (~375-414px) for issue #26 ("Rail nav / dense tables not verified on mobile viewport widths"). Findings:

- **Confirmed and fixed the one real gap**: neither `base.html` nor `login.html` (which doesn't extend `base.html`) had a `<meta name="viewport">` tag. Without it, mobile browsers render the page at a virtual desktop width (~980px) and let the user pinch-zoom, which means none of the existing responsive CSS below actually engages on a real device regardless of how well-written it is. Added `<meta name="viewport" content="width=device-width, initial-scale=1">` to both.
- **Everything else audited turned out to already be handled**, from an earlier mobile-usability pass (`3cf3089 (fix) Improve mobile usability: bigger tap targets, fix inline-form overlap`) already on `dev`:
  - `app/static/css/input.css` already has a `@media (max-width: 640px)` block that force-collapses the rail nav to icon-only, hides the now-redundant collapse toggle, bumps `.field` to 16px (avoids iOS Safari's auto-zoom-on-focus), and enlarges tap targets on `.icon-btn`/`.add-btn`/`.btn-secondary`.
  - Every dense table (`led`) across Expenses/Overview/Goals/Credit/Assets is already wrapped in `.table-wrap` (`overflow-x-auto`), so tables scroll horizontally within their own container on narrow viewports instead of breaking page layout.
  - The Cash Flow canvas's drag/connect/pan interactions are implemented via unified Pointer Events (`pointerdown`/`pointermove`/`pointerup` in `cashflow.js`), which already work on touch as well as mouse -- no separate touch-gesture rewrite needed. The canvas also already has explicit zoom in/out buttons (`.canvas-zoom-control`) as a non-drag alternative to scroll-to-zoom.
  - Card/stat rows (Overview) and inline edit forms (Expenses) already use `flex-wrap` with `min-w-[...]` rather than a fixed-column grid, so they stack cleanly rather than overflow.

**Known limitation of this PR**: this environment has no `playwright`/browser-automation tooling and no `tailwindcss` binary available, so this was a code-level audit (reading the compiled CSS rules, media queries, and event-handling code) rather than an actual on-device/browser visual check. The viewport meta tag fix in particular is high-confidence since its absence is unambiguous and it's a prerequisite for any of the other responsive CSS to apply at all. Recommend an actual device/browser-devtools pass as a follow-up to visually confirm, especially for the Cash Flow canvas's touch drag feel.

## Test plan
- [x] `poetry run ruff check .` / `poetry run ruff format . --check`
- [x] `poetry run mypy app tests`
- [ ] `poetry run djlint app/templates --profile jinja --check` -- blocked locally by a Device Guard policy in this environment (same known issue as PR #31); CI will run it
- [x] `poetry run python -m pytest` -- 101 passed
- [ ] Manual on-device/browser-devtools mobile viewport check -- not performed due to lack of browser automation tooling in this environment; recommended as a follow-up
