### PR TITLE
(feat) Surface negative-balance cash flow warnings on Overview

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -756,6 +756,15 @@ def cashflow_warnings(db: Session, payout_period_id: int, user_id: int) -> dict[
     return {"unfunded_channels": unfunded_channels, "underfunded_goals": underfunded_goals}
 
 
+def overview_warnings(db: Session, user_id: int) -> list[dict]:
+    entries = []
+    for period in list_payout_periods(db, user_id):
+        warnings = cashflow_warnings(db, period.id, user_id)
+        if warnings["unfunded_channels"] or warnings["underfunded_goals"]:
+            entries.append({"period": period, "warnings": warnings})
+    return entries
+
+
 # --- Assets ---------------------------------------------------------------
 
 
@@ -997,6 +1006,7 @@ def overview_page_data(db: Session, user_id: int) -> dict:
         "net_worth": total_assets - total_liabilities,
         "goals": [{"goal": g, **goal_progress(g)} for g in list_goals(db, user_id)],
         "credit_lines": [{"line": c, **credit_utilization(c)} for c in credit_lines],
+        "period_warnings": overview_warnings(db, user_id),
     }
 
 

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -6,6 +6,24 @@
       <div class="page-sub">Net worth and progress at a glance</div>
     </div>
   </div>
+  {% if period_warnings %}
+    <div class="section">
+      <div class="section-title">
+        Cash flow warnings
+        <span class="pill">{{ period_warnings|length }} period{{ 's' if period_warnings|length != 1 else '' }}</span>
+      </div>
+      <div class="warn-banner">
+        {% for entry in period_warnings %}
+          {% for name in entry.warnings.unfunded_channels %}
+            <span class="warn-pill warn-red">{{ name }} goes negative on the {{ entry.period.label }}</span>
+          {% endfor %}
+          {% for name in entry.warnings.underfunded_goals %}
+            <span class="warn-pill warn-amber">{{ name }} isn't fully funded on the {{ entry.period.label }}</span>
+          {% endfor %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
   <div class="flex flex-wrap gap-4 mb-5">
     <div class="card flex-1 min-w-[10rem]">
       <div class="card-label">Total assets</div>

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -3,6 +3,23 @@ import re
 from fastapi.testclient import TestClient
 
 
+def _create_channel(client: TestClient, name: str) -> str:
+    response = client.post("/channels", data={"name": name, "color": "#8a8a8a"})
+    match = re.search(rf'value="{re.escape(name)}">.*?/channels/(\d+)"', response.text, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _create_payout_period(client: TestClient, label: str, income: str, channel_id: str) -> str:
+    response = client.post(
+        "/payout-periods",
+        data={"label": label, "income_amount": income, "receiving_channel_id": channel_id},
+    )
+    matches = re.findall(r"/payout-periods/(\d+)", response.text)
+    assert matches
+    return matches[-1]
+
+
 def test_overview_empty_state(client: TestClient) -> None:
     response = client.get("/overview")
     assert response.status_code == 200
@@ -97,6 +114,29 @@ def test_overview_shows_warn_pill_for_over_limit_credit(client: TestClient) -> N
     assert response.status_code == 200
     assert "warn-red" in response.text
     assert "Over limit" in response.text
+
+
+def test_overview_shows_no_cash_flow_warnings_section_when_none(client: TestClient) -> None:
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert "Cash flow warnings" not in response.text
+
+
+def test_overview_surfaces_unfunded_channel_warning(client: TestClient) -> None:
+    a = _create_channel(client, "Channel A")
+    b = _create_channel(client, "Channel B")
+    period_id = _create_payout_period(client, "15th", "0", a)
+
+    client.post(
+        "/expenses",
+        data={"name": "B bill", "amount": "500", "payout_period_id": period_id, "channel_id": b},
+    )
+
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert "Cash flow warnings" in response.text
+    assert "Channel B goes negative on the 15th" in response.text
+    assert "warn-red" in response.text
 
 
 def test_unknown_section_still_404s(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Closes #24. Investigated `crud.channel_balances()`/`crud.cashflow_warnings()` and confirmed the issue: warnings were only ever rendered on the Cash Flow canvas (`partials/cashflow_page.html`) via `data.warnings`. Overview had no visibility into negative/underfunded channels at all.
- Added `crud.overview_warnings(db, user_id)`, which runs `cashflow_warnings()` across every payout period and returns only the periods that have at least one warning.
- Wired the result into `overview_page_data()` as `period_warnings`, and added a new "Cash flow warnings" section to `partials/overview_page.html` (reusing the existing `warn-banner`/`warn-pill warn-red`/`warn-pill warn-amber` styles from the canvas) — e.g. "Channel B goes negative on the 15th". Section is omitted entirely when there are no warnings.
- Payout periods are recurring labels (not literal dates, per `PayoutPeriod.label`), so this surfaces warnings across all periods rather than picking a single "next" one.

## Test plan
- [x] `poetry run python -m pytest` (103 passed) — added `test_overview_shows_no_cash_flow_warnings_section_when_none` and `test_overview_surfaces_unfunded_channel_warning` (mirrors the existing `test_unfunded_channel_shows_warning` cashflow test setup)
- [x] `poetry run python -m ruff check .` / `ruff format --check .`
- [x] `poetry run python -m mypy app tests`
- [x] `poetry run python -m djlint app/templates --profile jinja --check`