### PR TITLE
(feat) Show upcoming expenses banner on Overview

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -986,17 +986,35 @@ def credit_page_data(db: Session, user_id: int) -> dict:
 # --- Composed view data -----------------------------------------------------
 
 
+def next_payout_period(db: Session, user_id: int) -> models.PayoutPeriod | None:
+    """The soonest-upcoming payout period. Periods have no calendar date (just a
+    user-facing label like "15th" and a display_order for cycling through them),
+    so "next" is the first one by display_order — the same ordering used
+    everywhere else periods are listed."""
+    periods = list_payout_periods(db, user_id)
+    return periods[0] if periods else None
+
+
 def overview_page_data(db: Session, user_id: int) -> dict:
     assets = list_assets(db, user_id)
     credit_lines = list_credit_lines(db, user_id)
     total_assets = sum(float(a.amount) for a in assets)
     total_liabilities = sum(float(c.used) for c in credit_lines)
+    period = next_payout_period(db, user_id)
+    upcoming_expenses = (
+        [e for e in list_expenses(db, user_id) if e.payout_period_id == period.id]
+        if period is not None
+        else []
+    )
     return {
         "total_assets": total_assets,
         "total_liabilities": total_liabilities,
         "net_worth": total_assets - total_liabilities,
         "goals": [{"goal": g, **goal_progress(g)} for g in list_goals(db, user_id)],
         "credit_lines": [{"line": c, **credit_utilization(c)} for c in credit_lines],
+        "next_payout_period": period,
+        "upcoming_expenses": upcoming_expenses,
+        "upcoming_expenses_total": sum(float(e.amount) for e in upcoming_expenses),
     }
 
 

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -6,6 +6,48 @@
       <div class="page-sub">Net worth and progress at a glance</div>
     </div>
   </div>
+  {% if next_payout_period %}
+    <div class="section">
+      <div class="section-title">
+        Upcoming — {{ next_payout_period.label }}<span class="pill">{{ upcoming_expenses|length }} due</span>
+      </div>
+      <div class="table-wrap">
+        <table class="led">
+          <colgroup>
+            <col class="min-w-28">
+            <col class="w-40">
+            <col class="w-32">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Expense</th>
+              <th>Channel</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for expense in upcoming_expenses %}
+              <tr>
+                <td>{{ expense.name }}</td>
+                <td>{{ macros.channel_label(expense.channel) }}</td>
+                <td class="num">{{ macros.peso(expense.amount) }}</td>
+              </tr>
+            {% else %}
+              {{ macros.empty_row(3, 'expenses due this period') }}
+            {% endfor %}
+          </tbody>
+          {% if upcoming_expenses %}
+            <tfoot>
+              <tr>
+                <td colspan="2" class="text-ink-soft">Total</td>
+                <td class="num">{{ macros.peso(upcoming_expenses_total) }}</td>
+              </tr>
+            </tfoot>
+          {% endif %}
+        </table>
+      </div>
+    </div>
+  {% endif %}
   <div class="flex flex-wrap gap-4 mb-5">
     <div class="card flex-1 min-w-[10rem]">
       <div class="card-label">Total assets</div>

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -8,6 +8,43 @@ def test_overview_empty_state(client: TestClient) -> None:
     assert response.status_code == 200
     assert "No goals yet" in response.text
     assert "No credit lines yet" in response.text
+    assert "Upcoming" not in response.text
+
+
+def test_overview_upcoming_expenses_banner(client: TestClient) -> None:
+    channel = client.post("/channels", data={"name": "Payroll", "color": "#8a8a8a"})
+    channel_id = re.search(r'/channels/(\d+)"', channel.text)
+    assert channel_id is not None
+    channel_id_str = channel_id.group(1)
+
+    period = client.post("/payout-periods", data={"label": "15th", "income_amount": "32000"})
+    period_id = re.search(r"/payout-periods/(\d+)", period.text)
+    assert period_id is not None
+    period_id_str = period_id.group(1)
+
+    client.post(
+        "/expenses",
+        data={
+            "name": "Meralco",
+            "amount": "2500.50",
+            "payout_period_id": period_id_str,
+            "channel_id": channel_id_str,
+        },
+    )
+
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert "Upcoming — 15th" in response.text
+    assert "Meralco" in response.text
+    assert "2,500.50" in response.text
+
+
+def test_overview_no_upcoming_banner_without_payout_periods(client: TestClient) -> None:
+    client.post("/assets", data={"name": "Some Asset", "amount": "100"})
+
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert "Upcoming" not in response.text
 
 
 def test_overview_kpi_totals(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Closes #21. The Overview page (already built out — CLAUDE.md's note about it being a placeholder is stale, it's a real route/template with net worth, goals, and credit sections) now shows an "Upcoming" section for the next payout period's expenses.
- `crud.next_payout_period()` picks the first payout period by `display_order` as "next" — payout periods have no calendar date in this data model, only a user-facing `label` (e.g. "15th") and a `display_order` used for cycling through them elsewhere in the app, so that's the closest available notion of "upcoming."
- `crud.overview_page_data()` now also returns `next_payout_period`, `upcoming_expenses`, and `upcoming_expenses_total`; the section is omitted entirely when there are no payout periods yet (matches the existing empty-state pattern).
- Scoped narrowly per the issue: no email/push, no full dashboard rework — just a banner/table matching the existing `.section`/`.led` styling used elsewhere on Overview and Expenses.

## Test plan
- [x] `poetry run ruff check .` / `ruff format .`
- [x] `poetry run mypy app tests` (via `python -m mypy`, since the `mypy.exe` entrypoint is blocked by local Device Guard policy — same workaround noted in prior PRs)
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 106 passed, including 2 new tests (banner renders next period's expenses + total; banner is absent with no payout periods) and an added assertion to the existing empty-state test