### PR TITLE
(feat) Add CSV export for ledger data

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -351,6 +351,15 @@ def list_transfers(db: Session, payout_period_id: int, user_id: int) -> list[mod
     return list(db.scalars(stmt))
 
 
+def list_all_transfers(db: Session, user_id: int) -> list[models.Transfer]:
+    stmt = (
+        select(models.Transfer)
+        .where(models.Transfer.user_id == user_id)
+        .order_by(models.Transfer.payout_period_id, models.Transfer.id)
+    )
+    return list(db.scalars(stmt))
+
+
 def create_transfer(db: Session, data: schemas.TransferCreate, user_id: int) -> models.Transfer:
     _require_owned(db, models.PayoutPeriod, data.payout_period_id, user_id, "Payout period")
     _require_owned(db, models.Channel, data.from_channel_id, user_id, "From channel")

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.routers import (
     channels,
     credit,
     expenses,
+    export,
     goal_contributions,
     goals,
     overview,
@@ -61,6 +62,7 @@ app.include_router(goals.router)
 app.include_router(credit.router)
 app.include_router(overview.router)
 app.include_router(cashflow.router)
+app.include_router(export.router)
 
 PLACEHOLDER_SECTIONS: dict[str, str] = {}
 

--- a/app/routers/export.py
+++ b/app/routers/export.py
@@ -1,0 +1,76 @@
+import csv
+from io import StringIO
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from app import crud, models
+from app.auth import get_current_user
+from app.database import get_db
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+def _csv_response(rows: list[list[object]], header: list[str], filename: str) -> Response:
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(header)
+    writer.writerows(rows)
+    return Response(
+        content=buffer.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/channels.csv")
+def export_channels(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    channels = crud.list_channels(db, current_user.id)
+    rows: list[list[object]] = [[c.name, c.color, c.channel_type or ""] for c in channels]
+    return _csv_response(rows, ["Name", "Color", "Type"], "channels.csv")
+
+
+@router.get("/payout-periods.csv")
+def export_payout_periods(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    periods = crud.list_payout_periods(db, current_user.id)
+    rows = [
+        [
+            p.label,
+            p.income_amount,
+            p.receiving_channel.name if p.receiving_channel else "",
+        ]
+        for p in periods
+    ]
+    return _csv_response(
+        rows, ["Label", "Income Amount", "Receiving Channel"], "payout-periods.csv"
+    )
+
+
+@router.get("/expenses.csv")
+def export_expenses(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    expenses = crud.list_expenses(db, current_user.id)
+    rows = [[e.name, e.amount, e.payout_period.label, e.channel.name] for e in expenses]
+    return _csv_response(rows, ["Name", "Amount", "Payout Period", "Channel"], "expenses.csv")
+
+
+@router.get("/transfers.csv")
+def export_transfers(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    transfers = crud.list_all_transfers(db, current_user.id)
+    rows = [
+        [t.payout_period.label, t.from_channel.name, t.to_channel.name, t.amount] for t in transfers
+    ]
+    return _csv_response(
+        rows, ["Payout Period", "From Channel", "To Channel", "Amount"], "transfers.csv"
+    )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,96 @@
+import re
+
+from fastapi.testclient import TestClient
+
+
+def _create_channel(client: TestClient, name: str, color: str = "#8a8a8a") -> str:
+    response = client.post("/channels", data={"name": name, "color": color})
+    match = re.search(rf'value="{re.escape(name)}">.*?/channels/(\d+)"', response.text, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _create_payout_period(client: TestClient, label: str, income: str, channel_id: str) -> str:
+    response = client.post(
+        "/payout-periods",
+        data={"label": label, "income_amount": income, "receiving_channel_id": channel_id},
+    )
+    matches = re.findall(r"/payout-periods/(\d+)", response.text)
+    assert matches
+    return matches[-1]
+
+
+def test_export_channels_csv(client: TestClient) -> None:
+    _create_channel(client, "BPI", "#B8122B")
+
+    response = client.get("/export/channels.csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert response.headers["content-disposition"] == 'attachment; filename="channels.csv"'
+    assert "Name,Color,Type" in response.text
+    assert "BPI,#B8122B" in response.text
+
+
+def test_export_payout_periods_csv(client: TestClient) -> None:
+    channel_id = _create_channel(client, "GCash", "#0072CE")
+    _create_payout_period(client, "15th", "1000", channel_id)
+
+    response = client.get("/export/payout-periods.csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"] == ('attachment; filename="payout-periods.csv"')
+    assert "Label,Income Amount,Receiving Channel" in response.text
+    assert "15th,1000.00,GCash" in response.text
+
+
+def test_export_expenses_csv(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BDO", "#003DA5")
+    period_id = _create_payout_period(client, "30th", "2000", channel_id)
+
+    client.post(
+        "/expenses",
+        data={
+            "name": "Meralco",
+            "amount": "1500",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+
+    response = client.get("/export/expenses.csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"] == 'attachment; filename="expenses.csv"'
+    assert "Name,Amount,Payout Period,Channel" in response.text
+    assert "Meralco,1500.00,30th,BDO" in response.text
+
+
+def test_export_transfers_csv(client: TestClient) -> None:
+    from_id = _create_channel(client, "Maya", "#0FA968")
+    to_id = _create_channel(client, "Savings", "#8a8a8a")
+    period_id = _create_payout_period(client, "15th", "1000", from_id)
+
+    client.post(
+        "/transfers",
+        data={
+            "payout_period_id": period_id,
+            "from_channel_id": from_id,
+            "to_channel_id": to_id,
+            "amount": "300",
+        },
+    )
+
+    response = client.get("/export/transfers.csv")
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"] == 'attachment; filename="transfers.csv"'
+    assert "Payout Period,From Channel,To Channel,Amount" in response.text
+    assert "15th,Maya,Savings,300.00" in response.text
+
+
+def test_export_empty_data_returns_header_only(client: TestClient) -> None:
+    response = client.get("/export/channels.csv")
+
+    assert response.status_code == 200
+    assert response.text.strip() == "Name,Color,Type"


### PR DESCRIPTION
## Summary
- Closes #22. Adds per-section CSV export: `GET /export/channels.csv`, `/export/payout-periods.csv`, `/export/expenses.csv`, `/export/transfers.csv`.
- Each route is a plain `GET` returning a `Response` with `Content-Type: text/csv` and `Content-Disposition: attachment` — no htmx interception needed, a plain link triggers a browser download.
- Scoped to the current user's data only, reusing existing `crud.py` list functions (`list_channels`, `list_payout_periods`, `list_expenses`) plus a new `crud.list_all_transfers(db, user_id)` (transfers previously only had a payout-period-scoped list function).
- Kept intentionally simple per the issue's "not urgent, flagging for later" framing — no combined export, no import/restore.

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` (106 passed) — new `tests/test_export.py` covers all four export routes plus an empty-data (header-only) case