### PR TITLE
(feat) Add authenticated change-password form

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -111,6 +111,11 @@ def register_successful_login(db: Session, user: models.User) -> None:
     db.commit()
 
 
+def update_password(db: Session, user: models.User, hashed_password: str) -> None:
+    user.hashed_password = hashed_password
+    db.commit()
+
+
 # --- Channels ---------------------------------------------------------------
 
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -7,9 +7,10 @@ from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
-from app import crud
-from app.auth import start_session, verify_password
+from app import crud, models
+from app.auth import get_current_user, hash_password, start_session, verify_password
 from app.database import get_db
+from app.manage_users import MIN_PASSWORD_LENGTH
 
 router = APIRouter(tags=["auth"])
 templates = Jinja2Templates(directory="app/templates")
@@ -67,3 +68,47 @@ def login(
 def logout(request: Request) -> Response:
     request.session.clear()
     return RedirectResponse(url="/login", status_code=303)
+
+
+@router.get("/account")
+def account_form(
+    request: Request, current_user: models.User = Depends(get_current_user)
+) -> Response:
+    return templates.TemplateResponse(request, "account.html", {"success": False})
+
+
+@router.post("/account/password")
+def change_password(
+    request: Request,
+    current_password: str = Form(...),
+    new_password: str = Form(...),
+    confirm_password: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    if not verify_password(current_password, current_user.hashed_password):
+        return templates.TemplateResponse(
+            request,
+            "account.html",
+            {"success": False, "error": "Current password is incorrect."},
+            status_code=401,
+        )
+    if new_password != confirm_password:
+        return templates.TemplateResponse(
+            request,
+            "account.html",
+            {"success": False, "error": "New passwords don't match."},
+            status_code=400,
+        )
+    if len(new_password) < MIN_PASSWORD_LENGTH:
+        return templates.TemplateResponse(
+            request,
+            "account.html",
+            {
+                "success": False,
+                "error": f"New password must be at least {MIN_PASSWORD_LENGTH} characters long.",
+            },
+            status_code=400,
+        )
+    crud.update_password(db, current_user, hash_password(new_password))
+    return templates.TemplateResponse(request, "account.html", {"success": True})

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block content %}
+  <div id="account-page">
+    <div class="page-head">
+      <div>
+        <div class="page-title">Account</div>
+        <div class="page-sub">Change your password</div>
+      </div>
+    </div>
+    <div class="card max-w-sm">
+      {% if success %}<p class="text-sm text-accent mb-4">Password updated.</p>{% endif %}
+      {% if error %}<p class="text-sm text-rust mb-4">{{ error }}</p>{% endif %}
+      <form method="post" action="/account/password" class="flex flex-col gap-3">
+        <input type="hidden"
+               name="csrf_token"
+               value="{{ request.session.csrf_token }}">
+        <input class="field"
+               type="password"
+               name="current_password"
+               placeholder="Current password"
+               required>
+        <input class="field"
+               type="password"
+               name="new_password"
+               placeholder="New password"
+               required>
+        <input class="field"
+               type="password"
+               name="confirm_password"
+               placeholder="Confirm new password"
+               required>
+        <button type="submit" class="add-btn mt-2">Update password</button>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,7 +46,18 @@
             <span class="tab-label">{{ label }}</span>
           </a>
         {% endfor %}
-        <form method="post" action="/logout" hx-boost="false" class="mt-auto">
+        <a class="tab mt-auto{{ ' tab-active' if request.url.path == '/account' else '' }}"
+           href="/account">
+          <svg class="tab-icon"
+               viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+          </svg>
+          <span class="tab-label">Account</span>
+        </a>
+        <form method="post" action="/logout" hx-boost="false">
           <input type="hidden"
                  name="csrf_token"
                  value="{{ request.session.csrf_token }}">

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -186,3 +186,81 @@ def test_cross_user_data_isolation(real_client: TestClient) -> None:
 
     expenses_page = real_client.get("/expenses")
     assert "Alice Bank" not in expenses_page.text
+
+
+def test_account_page_requires_login(real_client: TestClient) -> None:
+    response = real_client.get("/account", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_change_password_success_and_relogin(real_client: TestClient) -> None:
+    _create_user("alice@example.com", "correct-horse")
+    real_client.post("/login", data={"email": "alice@example.com", "password": "correct-horse"})
+
+    response = real_client.post(
+        "/account/password",
+        data={
+            "current_password": "correct-horse",
+            "new_password": "new-correct-horse",
+            "confirm_password": "new-correct-horse",
+        },
+    )
+    assert response.status_code == 200
+    assert "Password updated" in response.text
+
+    real_client.post("/logout")
+    relogin = real_client.post(
+        "/login",
+        data={"email": "alice@example.com", "password": "new-correct-horse"},
+        follow_redirects=False,
+    )
+    assert relogin.status_code == 303
+
+
+def test_change_password_rejects_wrong_current_password(real_client: TestClient) -> None:
+    _create_user("alice@example.com", "correct-horse")
+    real_client.post("/login", data={"email": "alice@example.com", "password": "correct-horse"})
+
+    response = real_client.post(
+        "/account/password",
+        data={
+            "current_password": "wrong-password",
+            "new_password": "new-correct-horse",
+            "confirm_password": "new-correct-horse",
+        },
+    )
+    assert response.status_code == 401
+    assert "Current password is incorrect" in response.text
+
+
+def test_change_password_rejects_mismatched_confirmation(real_client: TestClient) -> None:
+    _create_user("alice@example.com", "correct-horse")
+    real_client.post("/login", data={"email": "alice@example.com", "password": "correct-horse"})
+
+    response = real_client.post(
+        "/account/password",
+        data={
+            "current_password": "correct-horse",
+            "new_password": "new-correct-horse",
+            "confirm_password": "something-else",
+        },
+    )
+    assert response.status_code == 400
+    assert "New passwords" in response.text and "match" in response.text
+
+
+def test_change_password_rejects_short_password(real_client: TestClient) -> None:
+    _create_user("alice@example.com", "correct-horse")
+    real_client.post("/login", data={"email": "alice@example.com", "password": "correct-horse"})
+
+    response = real_client.post(
+        "/account/password",
+        data={
+            "current_password": "correct-horse",
+            "new_password": "short",
+            "confirm_password": "short",
+        },
+    )
+    assert response.status_code == 400
+    assert "at least" in response.text


### PR DESCRIPTION
## Summary
Investigated issue #27 (\"No account self-service: no forgot-password flow, no email verification\"). The issue's own suggested fix says full self-service is \"likely won't-fix given current scope\" for this single-operator household app -- and this PR does **not** build forgot-password or email verification.

However, confirmed there was genuinely no in-app path at all for a logged-in user to change their own password -- only the operator-run \`manage_users.py set-password\` CLI. That gap seemed worth closing even though full self-service stays out of scope:

- New \`GET /account\` / \`POST /account/password\` routes (\`app/routers/auth.py\`), requiring the existing \`get_current_user\` auth dependency.
- Verifies the current password (\`verify_password\`), requires new/confirm to match, and enforces the same \`MIN_PASSWORD_LENGTH\` (12) already used by \`manage_users.py\` -- imported from there rather than duplicated.
- New \`crud.update_password()\` helper.
- New \`app/templates/account.html\`, following the existing page-head/card/field conventions; added an \"Account\" link to the rail nav next to Logout.

Addresses part of #27 -- not closing it, since full self-service (forgot-password, email verification) remains an intentional won't-fix for now.

## Test plan
- [x] \`poetry run ruff check .\` / \`ruff format --check .\`
- [x] \`poetry run mypy app tests\`
- [x] \`poetry run djlint app/templates --profile jinja --check\`
- [x] \`poetry run pytest\` -- 106 passed, including new coverage: \`/account\` requires login, successful change + re-login with the new password, wrong current password rejected, mismatched confirmation rejected, too-short new password rejected