### PR TITLE
(fix) Account page nested nav bar and rail wordmark removal

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -70,11 +70,18 @@ def logout(request: Request) -> Response:
     return RedirectResponse(url="/login", status_code=303)
 
 
+def _account_response(
+    request: Request, context: dict[str, object], status_code: int = 200
+) -> Response:
+    template = "partials/account_page.html" if request.headers.get("HX-Request") else "account.html"
+    return templates.TemplateResponse(request, template, context, status_code=status_code)
+
+
 @router.get("/account")
 def account_form(
     request: Request, current_user: models.User = Depends(get_current_user)
 ) -> Response:
-    return templates.TemplateResponse(request, "account.html", {"success": False})
+    return _account_response(request, {"success": False})
 
 
 @router.post("/account/password")
@@ -87,23 +94,16 @@ def change_password(
     current_user: models.User = Depends(get_current_user),
 ) -> Response:
     if not verify_password(current_password, current_user.hashed_password):
-        return templates.TemplateResponse(
-            request,
-            "account.html",
-            {"success": False, "error": "Current password is incorrect."},
-            status_code=401,
+        return _account_response(
+            request, {"success": False, "error": "Current password is incorrect."}, status_code=401
         )
     if new_password != confirm_password:
-        return templates.TemplateResponse(
-            request,
-            "account.html",
-            {"success": False, "error": "New passwords don't match."},
-            status_code=400,
+        return _account_response(
+            request, {"success": False, "error": "New passwords don't match."}, status_code=400
         )
     if len(new_password) < MIN_PASSWORD_LENGTH:
-        return templates.TemplateResponse(
+        return _account_response(
             request,
-            "account.html",
             {
                 "success": False,
                 "error": f"New password must be at least {MIN_PASSWORD_LENGTH} characters long.",
@@ -111,4 +111,4 @@ def change_password(
             status_code=400,
         )
     crud.update_password(db, current_user, hash_password(new_password))
-    return templates.TemplateResponse(request, "account.html", {"success": True})
+    return _account_response(request, {"success": True})

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -41,12 +41,6 @@
   .rail-logo {
     @apply flex items-center justify-center w-8 h-8 rounded-lg bg-accent font-serif font-bold text-base text-white shrink-0;
   }
-  .rail-wordmark {
-    @apply font-serif font-semibold text-lg text-white leading-tight min-w-0;
-  }
-  .rail-wordmark small {
-    @apply block font-sans font-normal text-[11px] text-white/70 mt-0.5 uppercase tracking-wide;
-  }
   .tab {
     @apply flex items-center gap-2.5 text-sm font-medium text-white/75 px-5 py-2.5 border-l-[3px] border-transparent hover:bg-white/10 hover:text-white transition-colors;
   }
@@ -471,7 +465,6 @@
   .rail {
     width: 4rem !important;
   }
-  .rail .rail-wordmark,
   .rail .tab-label {
     display: none !important;
   }

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -1,36 +1,4 @@
 {% extends "base.html" %}
 {% block content %}
-  <div id="account-page">
-    <div class="page-head">
-      <div>
-        <div class="page-title">Account</div>
-        <div class="page-sub">Change your password</div>
-      </div>
-    </div>
-    <div class="card max-w-sm">
-      {% if success %}<p class="text-sm text-accent mb-4">Password updated.</p>{% endif %}
-      {% if error %}<p class="text-sm text-rust mb-4">{{ error }}</p>{% endif %}
-      <form method="post" action="/account/password" class="flex flex-col gap-3">
-        <input type="hidden"
-               name="csrf_token"
-               value="{{ request.session.csrf_token }}">
-        <input class="field"
-               type="password"
-               name="current_password"
-               placeholder="Current password"
-               required>
-        <input class="field"
-               type="password"
-               name="new_password"
-               placeholder="New password"
-               required>
-        <input class="field"
-               type="password"
-               name="confirm_password"
-               placeholder="Confirm new password"
-               required>
-        <button type="submit" class="add-btn mt-2">Update password</button>
-      </form>
-    </div>
-  </div>
+  {% include "partials/account_page.html" %}
 {% endblock content %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -22,10 +22,6 @@
         <div class="rail-head" id="rail-head">
           <div class="rail-brand" id="rail-brand">
             <div class="rail-logo">L</div>
-            <div class="rail-wordmark" id="rail-wordmark">
-              Ledger
-              <small>Household Finance</small>
-            </div>
           </div>
           <button class="shrink-0 bg-white/15 text-white rounded w-6 h-6 flex items-center justify-center cursor-pointer hover:bg-white/25"
                   id="collapse-toggle"
@@ -107,7 +103,6 @@
 
       const rail = document.getElementById("rail");
       const railHead = document.getElementById("rail-head");
-      const wordmark = document.getElementById("rail-wordmark");
       const icon = document.getElementById("collapse-icon");
       const labels = () => document.querySelectorAll(".tab-label");
 
@@ -117,7 +112,6 @@
         railHead.classList.toggle("flex-col", collapsed);
         railHead.classList.toggle("gap-2", collapsed);
         railHead.classList.toggle("justify-between", !collapsed);
-        wordmark.style.display = collapsed ? "none" : "";
         labels().forEach((el) => { el.style.display = collapsed ? "none" : ""; });
         icon.textContent = collapsed ? "›" : "‹";
       }

--- a/app/templates/partials/account_page.html
+++ b/app/templates/partials/account_page.html
@@ -1,0 +1,33 @@
+<div id="account-page">
+  <div class="page-head">
+    <div>
+      <div class="page-title">Account</div>
+      <div class="page-sub">Change your password</div>
+    </div>
+  </div>
+  <div class="card max-w-sm">
+    {% if success %}<p class="text-sm text-accent mb-4">Password updated.</p>{% endif %}
+    {% if error %}<p class="text-sm text-rust mb-4">{{ error }}</p>{% endif %}
+    <form method="post" action="/account/password" class="flex flex-col gap-3">
+      <input type="hidden"
+             name="csrf_token"
+             value="{{ request.session.csrf_token }}">
+      <input class="field"
+             type="password"
+             name="current_password"
+             placeholder="Current password"
+             required>
+      <input class="field"
+             type="password"
+             name="new_password"
+             placeholder="New password"
+             required>
+      <input class="field"
+             type="password"
+             name="confirm_password"
+             placeholder="Confirm new password"
+             required>
+      <button type="submit" class="add-btn mt-2">Update password</button>
+    </form>
+  </div>
+</div>

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -27,3 +27,19 @@ def test_plain_request_returns_full_page(client: TestClient) -> None:
     assert 'id="goals-page"' in response.text
     assert "<html" in response.text
     assert 'id="rail"' in response.text
+
+
+def test_boosted_account_request_returns_fragment_only(client: TestClient) -> None:
+    response = client.get("/account", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    assert 'id="account-page"' in response.text
+    assert "<html" not in response.text
+    assert "<nav" not in response.text
+
+
+def test_plain_account_request_returns_full_page(client: TestClient) -> None:
+    response = client.get("/account")
+    assert response.status_code == 200
+    assert 'id="account-page"' in response.text
+    assert "<html" in response.text
+    assert 'id="rail"' in response.text


### PR DESCRIPTION
## Summary
- Closes #44. `GET /account`/`POST /account/password` always rendered the full `account.html` (extends `base.html`) regardless of `HX-Request`, so clicking the boosted "Account" nav link swapped a whole second page shell (rail + all) into `#page-content`. Split the page content into `partials/account_page.html` and pick the template based on `HX-Request`, following `overview.py`'s existing fragment-contract pattern.
- Closes #45. Removed the "Ledger / Household Finance" wordmark from the rail nav (`base.html`'s `#rail-wordmark`), along with its now-dead CSS (`.rail-wordmark`, mobile `display: none` override) and the collapse-toggle JS reference to it. The `L` logo square stays.

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 120 passed, including two new `test_navigation.py` cases covering the account page's boosted-vs-plain fragment contract (would have failed against the pre-fix nested-nav behavior)