### PR TITLE
(feat) Redesign the app as a bound ledger, with light/dark theming

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -15,44 +15,204 @@
 @theme {
   --color-ink: #1c2b2b;
   --color-ink-soft: #4b5d5d;
-  --color-paper: #fafafa;
-  --color-paper-dim: #ececec;
-  --color-card: #ffffff;
-  --color-line: #dcdcdc;
+  --color-paper: #f3f0e3;
+  --color-paper-dim: #e9e3cf;
+  --color-paper-line: rgba(22, 33, 21, 0.08);
+  --color-card: #fffdf6;
+  --color-line: #dcd5c0;
   --color-accent: #2f6d4f;
   --color-gold: #b6872f;
   --color-gold-soft: #f1e2bc;
   --color-rust: #a83f28;
   --color-rust-soft: #f0dcd2;
+  /* "-strong" fill tokens are for solid chips/buttons carrying fixed white
+     text (.add-btn, .entry-tab, canvas badges). --color-accent/--color-gold/
+     --color-rust brighten in dark mode for legibility as *foreground* text
+     on dark paper, which would fail contrast as a *background* under white
+     text -- these stay dark/saturated in both themes instead. */
+  --color-accent-strong: #2f6d4f;
+  --color-rust-strong: #a83f28;
+  /* The rail/spine is a book cover: it stays this same dark green
+     regardless of the paper theme, so it isn't part of the dark-mode
+     override block below. */
+  --color-cover: #0e2620;
+  --color-cover-soft: rgba(243, 240, 227, 0.62);
+  --color-cover-line: rgba(243, 240, 227, 0.14);
   --font-serif: "Fraunces", serif;
   --font-mono: "IBM Plex Mono", monospace;
 }
 
+/* Plain (non-@theme) tokens: referenced only via var() in hand-written CSS
+   below, never as Tailwind utilities, so they don't belong in @theme's
+   color/font namespaces. */
+:root {
+  --canvas-grid-line: rgba(28, 43, 43, 0.055);
+  --canvas-margin-line: rgba(168, 63, 40, 0.14);
+}
+
+/* Paper-theme tokens only -- --color-cover* is deliberately excluded, see
+   the comment in @theme above. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-ink: #f1ede0;
+    --color-ink-soft: #aab6ae;
+    --color-paper: #121e1a;
+    --color-paper-dim: #182924;
+    --color-paper-line: rgba(240, 237, 224, 0.07);
+    --color-card: #1a2b26;
+    --color-line: rgba(241, 237, 224, 0.14);
+    --color-accent: #57a17c;
+    --color-gold: #d7ab5a;
+    --color-gold-soft: rgba(215, 171, 90, 0.16);
+    --color-rust: #d97a5c;
+    --color-rust-soft: rgba(217, 122, 92, 0.16);
+    --color-accent-strong: #3c8262;
+    --color-rust-strong: #b8543a;
+    --canvas-grid-line: rgba(240, 237, 224, 0.06);
+    --canvas-margin-line: rgba(217, 122, 92, 0.22);
+  }
+}
+
+:root[data-theme="dark"] {
+  --color-ink: #f1ede0;
+  --color-ink-soft: #aab6ae;
+  --color-paper: #121e1a;
+  --color-paper-dim: #182924;
+  --color-paper-line: rgba(240, 237, 224, 0.07);
+  --color-card: #1a2b26;
+  --color-line: rgba(241, 237, 224, 0.14);
+  --color-accent: #57a17c;
+  --color-gold: #d7ab5a;
+  --color-gold-soft: rgba(215, 171, 90, 0.16);
+  --color-rust: #d97a5c;
+  --color-rust-soft: rgba(217, 122, 92, 0.16);
+  --color-accent-strong: #3c8262;
+  --color-rust-strong: #b8543a;
+  --canvas-grid-line: rgba(240, 237, 224, 0.06);
+  --canvas-margin-line: rgba(217, 122, 92, 0.22);
+}
+
+:root[data-theme="light"] {
+  --color-ink: #1c2b2b;
+  --color-ink-soft: #4b5d5d;
+  --color-paper: #f3f0e3;
+  --color-paper-dim: #e9e3cf;
+  --color-paper-line: rgba(22, 33, 21, 0.08);
+  --color-card: #fffdf6;
+  --color-line: #dcd5c0;
+  --color-accent: #2f6d4f;
+  --color-gold: #b6872f;
+  --color-gold-soft: #f1e2bc;
+  --color-rust: #a83f28;
+  --color-rust-soft: #f0dcd2;
+  --color-accent-strong: #2f6d4f;
+  --color-rust-strong: #a83f28;
+  --canvas-grid-line: rgba(28, 43, 43, 0.055);
+  --canvas-margin-line: rgba(168, 63, 40, 0.14);
+}
+
 @layer components {
   .rail {
-    @apply w-52 shrink-0 bg-ink flex flex-col gap-1 py-5 transition-[width] duration-200 ease-in-out;
+    @apply w-52 shrink-0 bg-cover flex flex-col gap-1 py-5 transition-[width] duration-200 ease-in-out relative;
+  }
+  /* Bound-ledger stitching along the spine's inner edge. */
+  .rail::after {
+    content: "";
+    @apply absolute top-2.5 bottom-2.5 right-2.5 w-px pointer-events-none;
+    background-image: repeating-linear-gradient(
+      to bottom,
+      var(--color-cover-line) 0,
+      var(--color-cover-line) 4px,
+      transparent 4px,
+      transparent 11px
+    );
   }
   .rail-head {
-    @apply flex items-center justify-between px-5 pb-4 mb-3 border-b border-white/20;
+    @apply flex items-center justify-between px-5 pb-4 mb-3 border-b border-cover-line;
   }
   .rail-brand {
     @apply flex items-center gap-2.5 min-w-0;
   }
   .rail-logo {
-    @apply flex items-center justify-center w-8 h-8 rounded-lg bg-accent font-serif font-bold text-base text-white shrink-0;
+    @apply flex items-center justify-center w-8 h-8 rounded border-[1.5px] border-gold font-serif font-bold text-base text-gold shrink-0;
   }
   .tab {
-    @apply flex items-center gap-2.5 text-sm font-medium text-white/75 px-5 py-2.5 border-l-[3px] border-transparent hover:bg-white/10 hover:text-white transition-colors;
+    @apply flex items-center gap-2.5 text-sm font-medium text-cover-soft px-5 py-2.5 border-l-[3px] border-transparent hover:bg-cover-line hover:text-white transition-colors;
   }
   .tab-icon {
     @apply w-5 h-5 shrink-0;
   }
   .tab-active {
-    @apply bg-white/15 text-white border-l-accent;
+    @apply bg-cover-line text-white border-l-gold;
   }
 
   .page {
     @apply flex-1 px-4 py-5 sm:px-6 sm:py-6 md:px-10 md:py-8 bg-paper overflow-y-auto overflow-x-hidden;
+    background-image: repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 27px,
+      var(--color-paper-line) 27px,
+      var(--color-paper-line) 28px
+    );
+  }
+
+  /* Mobile bottom tab bar -- replaces the rail below the sm breakpoint,
+     see the max-width media query at the bottom of this file. */
+  .tabbar {
+    @apply hidden fixed bottom-0 left-0 right-0 z-40 bg-cover items-stretch;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    border-top: 1px solid var(--color-cover-line);
+  }
+  .tabbar-item {
+    @apply flex-1 flex flex-col items-center justify-center gap-1 py-2 text-[10.5px] font-medium text-cover-soft;
+  }
+  .tabbar-item.tab-active {
+    @apply bg-transparent text-gold border-l-0;
+  }
+  .tabbar-icon {
+    @apply w-5 h-5;
+  }
+  .more-sheet {
+    @apply hidden fixed inset-0 z-50 items-end justify-center bg-ink/50;
+  }
+  .more-sheet.flex {
+    @apply flex;
+  }
+  .more-sheet-panel {
+    @apply w-full bg-card rounded-t-xl shadow-lg p-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))];
+    animation: sheet-up 0.16s cubic-bezier(0.2, 0.9, 0.3, 1);
+  }
+  @keyframes sheet-up {
+    from { transform: translateY(12px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .more-sheet-panel { animation: none; }
+  }
+  .more-sheet-item {
+    @apply flex items-center gap-3 text-sm font-medium text-ink px-4 py-3 rounded-lg hover:bg-paper-dim;
+  }
+  .more-sheet-item svg {
+    @apply w-5 h-5 text-ink-soft shrink-0;
+  }
+
+  /* Ledger index-card treatment shared by .section and .card -- lets
+     .entry-tab position itself against the card's own top edge. */
+  .section,
+  .card {
+    @apply relative;
+  }
+  .entry-tab {
+    @apply absolute -top-2 left-4 text-[10px] font-bold uppercase tracking-wide text-white bg-accent-strong px-2 py-0.5 rounded-sm;
+  }
+  /* Gold is too light for white text in either theme -- .rail-logo/-cover
+     is a fixed dark tone regardless of theme, so it stays legible here. */
+  .entry-tab-gold {
+    @apply bg-gold text-cover;
+  }
+  .entry-tab-rust {
+    @apply bg-rust-strong;
   }
   .page-head {
     @apply flex items-baseline justify-between gap-3 flex-wrap mb-5;
@@ -113,7 +273,7 @@
     @apply inline-flex items-center p-1 rounded text-ink-soft hover:bg-rust-soft hover:text-rust cursor-pointer;
   }
   .add-btn {
-    @apply inline-flex items-center gap-1.5 bg-accent text-white text-xs font-semibold px-3 py-1.5 rounded-md hover:brightness-90 cursor-pointer mt-2;
+    @apply inline-flex items-center gap-1.5 bg-accent-strong text-white text-xs font-semibold px-3 py-1.5 rounded-md hover:brightness-90 cursor-pointer mt-2;
   }
   .btn-secondary {
     @apply inline-flex items-center text-ink-soft text-xs font-semibold px-3 py-1.5 rounded-md border border-line hover:bg-paper-dim cursor-pointer;
@@ -192,8 +352,17 @@
     @apply h-full rounded-full bg-accent;
   }
 
+  /* Styled like a rubber ink stamp: a double ring and a slight tilt that
+     straightens on hover. */
   .warn-pill {
-    @apply inline-flex items-center gap-1 text-[11px] font-bold px-2.5 py-1 rounded-full whitespace-nowrap;
+    @apply inline-flex items-center gap-1 text-[11px] font-bold px-2.5 py-1 rounded-full whitespace-nowrap border-[1.5px] border-current;
+    outline: 1px solid currentColor;
+    outline-offset: -3px;
+    transform: rotate(-1.5deg);
+    transition: transform 0.15s ease;
+  }
+  .warn-pill:hover {
+    transform: rotate(0deg);
   }
   .warn-amber {
     @apply bg-gold-soft text-gold;
@@ -222,12 +391,12 @@
     @apply relative w-full min-h-[520px] rounded-lg border border-line overflow-hidden touch-none;
     background-color: var(--color-paper-dim);
     background-image:
-      linear-gradient(rgba(28, 43, 43, 0.055) 1px, transparent 1px),
+      linear-gradient(var(--canvas-grid-line) 1px, transparent 1px),
       linear-gradient(
         90deg,
         transparent 63px,
-        rgba(168, 63, 40, 0.14) 63px,
-        rgba(168, 63, 40, 0.14) 64px,
+        var(--canvas-margin-line) 63px,
+        var(--canvas-margin-line) 64px,
         transparent 64px
       );
     background-size:
@@ -247,7 +416,7 @@
     border-left: 4px solid var(--rail, var(--color-accent));
   }
   .canvas-node-remove {
-    @apply absolute -right-1.5 -top-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-ink text-white text-[10px] leading-none cursor-pointer z-20 hover:bg-rust;
+    @apply absolute -right-1.5 -top-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-cover text-white text-[10px] leading-none cursor-pointer z-20 hover:bg-rust-strong;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.1s ease;
@@ -354,7 +523,7 @@
     box-shadow: 0 0 0 4px var(--color-rust-soft);
   }
   .canvas-node-warn-badge {
-    @apply absolute -left-1.5 -top-1.5 w-4 h-4 items-center justify-center rounded-full bg-rust text-white z-20;
+    @apply absolute -left-1.5 -top-1.5 w-4 h-4 items-center justify-center rounded-full bg-rust-strong text-white z-20;
     display: none;
   }
   .canvas-node-warn .canvas-node-warn-badge {
@@ -462,22 +631,16 @@
 }
 
 @media (max-width: 640px) {
+  /* Mobile trades the spine for a bottom tab bar entirely, rather than a
+     shrunk desktop rail -- see .tabbar in the components layer above. */
   .rail {
-    width: 4rem !important;
-  }
-  .rail .tab-label {
     display: none !important;
   }
-  .rail-head {
-    flex-direction: column;
-    gap: 0.5rem;
-    justify-content: center !important;
+  .tabbar {
+    display: flex !important;
   }
-  /* Width is forced above regardless of the collapsed/expanded JS state, so
-     the toggle button has no effect on mobile — hide it rather than leave a
-     dead control. */
-  #collapse-toggle {
-    display: none !important;
+  .page {
+    padding-bottom: calc(4.25rem + env(safe-area-inset-bottom, 0px));
   }
 
   /* Keep inputs at >=16px so iOS Safari doesn't auto-zoom the page on focus. */

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -256,8 +256,12 @@
     @apply bg-rust-soft text-rust;
   }
 
+  /* No w-full: table-fixed sizes to the sum of each <col>'s width, so the
+     table only takes the room its columns actually need instead of
+     stretching to fill a much wider .section (leaving noticeable gaps
+     on tables with few/narrow columns, e.g. Goals, Credit, Assets). */
   .led {
-    @apply w-full min-w-max table-fixed text-[13.5px] border-collapse;
+    @apply min-w-max table-fixed text-[13.5px] border-collapse;
   }
   .led th {
     @apply text-left text-[11px] uppercase tracking-wide text-ink-soft font-semibold px-2.5 py-1.5 border-b-2 border-ink;
@@ -370,8 +374,27 @@
   .warn-red {
     @apply bg-rust-soft text-rust;
   }
+  .warn-banner-wrap {
+    @apply relative mb-3;
+  }
   .warn-banner {
-    @apply flex flex-wrap gap-2 mb-3;
+    @apply flex gap-2 overflow-hidden pr-9;
+    max-height: 2rem;
+  }
+  .warn-banner-wrap.expanded .warn-banner {
+    @apply flex-wrap;
+    max-height: none;
+    overflow: visible;
+  }
+  .warn-fade {
+    @apply absolute top-0 right-8 bottom-0 w-10 pointer-events-none;
+    background: linear-gradient(to right, transparent, var(--color-card));
+  }
+  .warn-banner-wrap.expanded .warn-fade {
+    @apply hidden;
+  }
+  .warn-toggle {
+    @apply absolute top-0 right-0 flex items-center justify-center w-7 h-7 rounded-full bg-card border border-line text-ink-soft text-xs font-bold cursor-pointer shadow-sm hover:text-ink hover:border-accent;
   }
 
   .toolbox {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
   </head>
   <body class="font-sans text-ink">
-    <div class="flex h-screen overflow-hidden bg-ink">
+    <div class="flex h-screen overflow-hidden bg-cover">
       <nav class="rail"
            id="rail"
            hx-boost="true"
@@ -54,6 +54,27 @@
           </svg>
           <span class="tab-label">Account</span>
         </a>
+        <button type="button"
+                id="theme-toggle"
+                class="tab w-full text-left bg-transparent cursor-pointer">
+          <svg class="tab-icon"
+               id="theme-icon-light"
+               viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0Z" />
+          </svg>
+          <svg class="tab-icon hidden"
+               id="theme-icon-dark"
+               viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998Z" />
+          </svg>
+          <span class="tab-label" id="theme-toggle-label">Dark mode</span>
+        </button>
         <form method="post" action="/logout" hx-boost="false">
           <input type="hidden"
                  name="csrf_token"
@@ -71,23 +92,119 @@
           </button>
         </form>
       </nav>
+      <nav class="tabbar"
+           id="tabbar"
+           hx-boost="true"
+           hx-target="#page-content"
+           hx-swap="innerHTML"
+           hx-push-url="true">
+        {% for href, label, icon_path in nav_items[:4] %}
+          <a class="tabbar-item{{ ' tab-active' if request.url.path == href else '' }}"
+             href="{{ href }}">
+            <svg class="tabbar-icon"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="{{ icon_path }}" />
+            </svg>
+            {{ label }}
+          </a>
+        {% endfor %}
+        <button type="button"
+                class="tabbar-item bg-transparent cursor-pointer"
+                onclick="toggleMoreSheet(true)">
+          <svg class="tabbar-icon"
+               viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM12.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM18.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+          </svg>
+          More
+        </button>
+      </nav>
       <div class="page" id="page-content">
         {% block content %}
         {% endblock content %}
       </div>
     </div>
+    <div id="more-sheet"
+         class="more-sheet"
+         onclick="if (event.target === this) toggleMoreSheet(false)">
+      <div class="more-sheet-panel">
+        {% for href, label, icon_path in nav_items[4:] %}
+          <a class="more-sheet-item"
+             href="{{ href }}"
+             hx-boost="true"
+             hx-target="#page-content"
+             hx-swap="innerHTML"
+             hx-push-url="true">
+            <svg viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="{{ icon_path }}" />
+            </svg>
+            {{ label }}
+          </a>
+        {% endfor %}
+        <a class="more-sheet-item"
+           href="/account"
+           hx-boost="true"
+           hx-target="#page-content"
+           hx-swap="innerHTML"
+           hx-push-url="true">
+          <svg viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+          </svg>
+          Account
+        </a>
+        <button type="button"
+                class="more-sheet-item w-full bg-transparent cursor-pointer"
+                onclick="toggleTheme()">
+          <svg viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0Z" />
+          </svg>
+          <span id="theme-toggle-label-mobile">Dark mode</span>
+        </button>
+        <form method="post" action="/logout" hx-boost="false">
+          <input type="hidden"
+                 name="csrf_token"
+                 value="{{ request.session.csrf_token }}">
+          <button type="submit"
+                  class="more-sheet-item w-full text-left bg-transparent cursor-pointer">
+            <svg viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l3 3m0 0l-3 3m3-3H3" />
+            </svg>
+            Log out
+          </button>
+        </form>
+      </div>
+    </div>
     <div id="confirm-modal"
-         class="fixed inset-0 z-50 hidden items-center justify-center bg-ink/50">
+         class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50">
       <div class="card w-full max-w-sm mx-4">
         <p id="confirm-modal-message" class="text-sm text-ink mb-4"></p>
         <div class="flex justify-end gap-2">
           <button type="button" id="confirm-modal-cancel" class="btn-secondary">Cancel</button>
-          <button type="button" id="confirm-modal-confirm" class="add-btn bg-rust mt-0">Delete</button>
+          <button type="button"
+                  id="confirm-modal-confirm"
+                  class="add-btn bg-rust-strong mt-0">Delete</button>
         </div>
       </div>
     </div>
     <div id="alert-modal"
-         class="fixed inset-0 z-50 hidden items-center justify-center bg-ink/50">
+         class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50">
       <div class="card w-full max-w-sm mx-4">
         <p id="alert-modal-message" class="text-sm text-ink mb-4"></p>
         <div class="flex justify-end">
@@ -100,6 +217,46 @@
       document.body.addEventListener("htmx:configRequest", (evt) => {
         evt.detail.headers["X-CSRF-Token"] = csrfToken;
       });
+
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+      const lightIcon = document.getElementById("theme-icon-light");
+      const darkIcon = document.getElementById("theme-icon-dark");
+      const themeLabel = document.getElementById("theme-toggle-label");
+      const themeLabelMobile = document.getElementById("theme-toggle-label-mobile");
+
+      function effectiveTheme() {
+        const stored = localStorage.getItem("theme");
+        if (stored === "light" || stored === "dark") return stored;
+        return prefersDark.matches ? "dark" : "light";
+      }
+
+      function applyTheme() {
+        const stored = localStorage.getItem("theme");
+        document.documentElement.setAttribute("data-theme", stored === "light" || stored === "dark" ? stored : "");
+        const isDark = effectiveTheme() === "dark";
+        lightIcon.classList.toggle("hidden", isDark);
+        darkIcon.classList.toggle("hidden", !isDark);
+        const label = isDark ? "Light mode" : "Dark mode";
+        themeLabel.textContent = label;
+        themeLabelMobile.textContent = label;
+      }
+
+      function toggleTheme() {
+        localStorage.setItem("theme", effectiveTheme() === "dark" ? "light" : "dark");
+        applyTheme();
+      }
+
+      document.getElementById("theme-toggle").addEventListener("click", toggleTheme);
+      prefersDark.addEventListener("change", () => {
+        if (localStorage.getItem("theme") === null) applyTheme();
+      });
+      applyTheme();
+
+      const moreSheet = document.getElementById("more-sheet");
+      function toggleMoreSheet(open) {
+        moreSheet.classList.toggle("flex", open);
+        moreSheet.classList.toggle("hidden", !open);
+      }
 
       const rail = document.getElementById("rail");
       const railHead = document.getElementById("rail-head");
@@ -250,7 +407,9 @@
       });
 
       document.addEventListener("keydown", (evt) => {
-        if (evt.key === "Escape") closeAllPresetPopovers();
+        if (evt.key !== "Escape") return;
+        closeAllPresetPopovers();
+        toggleMoreSheet(false);
       });
 
       function applyChannelPreset(name, color, channelType, badgeLabel, itemEl) {
@@ -271,13 +430,16 @@
 
       function updateActiveTab() {
         const path = location.pathname;
-        document.querySelectorAll(".tab").forEach((tab) => {
+        document.querySelectorAll(".tab, .tabbar-item").forEach((tab) => {
           tab.classList.toggle("tab-active", tab.getAttribute("href") === path);
         });
       }
 
       document.body.addEventListener("htmx:afterSettle", (evt) => {
-        if (evt.detail.target && evt.detail.target.id === "page-content") updateActiveTab();
+        if (evt.detail.target && evt.detail.target.id === "page-content") {
+          updateActiveTab();
+          toggleMoreSheet(false);
+        }
       });
     </script>
     <script src="{{ url_for('static', path='js/cashflow.js') }}?v=19"></script>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -258,6 +258,13 @@
         moreSheet.classList.toggle("hidden", !open);
       }
 
+      function toggleWarnBanner(wrapId, btn) {
+        const wrap = document.getElementById(wrapId);
+        const expanded = wrap.classList.toggle("expanded");
+        btn.textContent = expanded ? "×" : "…";
+        btn.setAttribute("aria-label", expanded ? "Show fewer warnings" : "Show all warnings");
+      }
+
       const rail = document.getElementById("rail");
       const railHead = document.getElementById("rail-head");
       const icon = document.getElementById("collapse-icon");

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -9,10 +9,13 @@
           rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
   </head>
-  <body class="font-sans text-ink bg-ink">
+  <body class="font-sans text-ink bg-cover">
     <div class="flex h-screen items-center justify-center">
       <div class="card w-full max-w-sm mx-4">
-        <div class="page-title mb-4">Ledger</div>
+        <div class="flex items-center gap-2.5 mb-4">
+          <div class="rail-logo">L</div>
+          <div class="page-title">Ledger</div>
+        </div>
         {% if error %}<p class="text-sm text-rust mb-4">{{ error }}</p>{% endif %}
         <form method="post" action="/login" class="flex flex-col gap-3">
           <input type="hidden"

--- a/app/templates/partials/account_page.html
+++ b/app/templates/partials/account_page.html
@@ -6,6 +6,7 @@
     </div>
   </div>
   <div class="card max-w-sm">
+    <span class="entry-tab">Account</span>
     {% if success %}<p class="text-sm text-accent mb-4">Password updated.</p>{% endif %}
     {% if error %}<p class="text-sm text-rust mb-4">{{ error }}</p>{% endif %}
     <form method="post" action="/account/password" class="flex flex-col gap-3">

--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -23,7 +23,7 @@
       <table class="led">
         <colgroup>
           <col class="min-w-28">
-          <col class="w-40">
+          <col class="w-36">
           <col class="w-32">
           <col class="w-28">
         </colgroup>

--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -7,10 +7,12 @@
     </div>
   </div>
   <div class="card mb-5 max-w-xs">
+    <span class="entry-tab">Balance</span>
     <div class="card-label">Total assets</div>
     <div class="card-value">{{ macros.peso(total_assets) }}</div>
   </div>
   <div class="section">
+    <span class="entry-tab">Assets</span>
     <div class="section-title">Assets<span class="pill">{{ assets|length }} items</span></div>
     <form id="add-asset-form"
           hx-post="/assets"

--- a/app/templates/partials/cashflow_page.html
+++ b/app/templates/partials/cashflow_page.html
@@ -10,6 +10,7 @@
   </div>
   {% for data in payout_data %}
     <div class="section">
+      <span class="entry-tab">Cash Flow</span>
       <div class="section-title">{{ data.period.label }} cash flow</div>
       {% if data.warnings.unfunded_channels or data.warnings.underfunded_goals %}
         <div class="warn-banner">

--- a/app/templates/partials/cashflow_page.html
+++ b/app/templates/partials/cashflow_page.html
@@ -13,13 +13,20 @@
       <span class="entry-tab">Cash Flow</span>
       <div class="section-title">{{ data.period.label }} cash flow</div>
       {% if data.warnings.unfunded_channels or data.warnings.underfunded_goals %}
-        <div class="warn-banner">
-          {% for name in data.warnings.unfunded_channels %}
-            <span class="warn-pill warn-red">{{ name }} is short this payout</span>
-          {% endfor %}
-          {% for name in data.warnings.underfunded_goals %}
-            <span class="warn-pill warn-amber">{{ name }} isn't fully funded this payout</span>
-          {% endfor %}
+        <div class="warn-banner-wrap" id="cashflow-warn-wrap-{{ data.period.id }}">
+          <div class="warn-banner">
+            {% for name in data.warnings.unfunded_channels %}
+              <span class="warn-pill warn-red">{{ name }} is short this payout</span>
+            {% endfor %}
+            {% for name in data.warnings.underfunded_goals %}
+              <span class="warn-pill warn-amber">{{ name }} isn't fully funded this payout</span>
+            {% endfor %}
+          </div>
+          <div class="warn-fade"></div>
+          <button type="button"
+                  class="warn-toggle"
+                  aria-label="Show all warnings"
+                  onclick="toggleWarnBanner('cashflow-warn-wrap-{{ data.period.id }}', this)">&hellip;</button>
         </div>
       {% endif %}
       <div class="toolbox">

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -7,6 +7,7 @@
     </div>
   </div>
   <div class="section">
+    <span class="entry-tab entry-tab-gold">Credit lines</span>
     <div class="section-title">Credit lines<span class="pill">{{ credit_lines|length }} total</span></div>
     <form id="add-credit-form"
           hx-post="/credit"

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -18,7 +18,7 @@
       <table class="led">
         <colgroup>
           <col class="min-w-28">
-          <col class="w-40">
+          <col class="w-36">
           <col class="w-28">
           <col class="w-28">
           <col class="w-44">

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -7,6 +7,7 @@
     </div>
   </div>
   <div class="section">
+    <span class="entry-tab">Channels</span>
     <div class="section-title">Channels<span class="pill">{{ channels|length }} total</span></div>
     <form id="add-channel-form"
           hx-post="/channels"
@@ -178,6 +179,7 @@
     </div>
   </div>
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels }}">
+    <span class="entry-tab entry-tab-gold">Payout periods</span>
     <div class="section-title">Payout periods<span class="pill">{{ payout_periods|length }} total</span></div>
     <form id="add-payout-form"
           hx-post="/payout-periods"
@@ -312,6 +314,7 @@
     </div>
   </div>
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels or not payout_periods }}">
+    <span class="entry-tab entry-tab-rust">Expenses</span>
     <div class="section-title">
       <span>Recurring expenses<span class="pill">{{ expenses|length }} items</span></span>
       <input id="expense-search"

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -339,7 +339,7 @@
         <colgroup>
           <col class="min-w-28">
           <col class="w-24">
-          <col class="w-40">
+          <col class="w-36">
           <col class="w-24">
           <col class="w-20">
         </colgroup>

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -18,7 +18,7 @@
       <table class="led">
         <colgroup>
           <col class="min-w-28">
-          <col class="w-40">
+          <col class="w-36">
           <col class="w-28">
           <col class="w-28">
           <col class="w-20">

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -7,6 +7,7 @@
     </div>
   </div>
   <div class="section">
+    <span class="entry-tab">Goals</span>
     <div class="section-title">Goals<span class="pill">{{ goals|length }} total</span></div>
     <form id="add-goal-form"
           hx-post="/goals"

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -6,8 +6,24 @@
       <div class="page-sub">Net worth and progress at a glance</div>
     </div>
   </div>
+  <div class="card mb-5">
+    <span class="entry-tab">Balance</span>
+    <div class="card-label">Net worth</div>
+    <div class="card-value text-2xl {{ 'card-value-neg' if net_worth < 0 else '' }}">{{ macros.peso(net_worth) }}</div>
+    <div class="flex gap-6 mt-3 pt-3 border-t border-dashed border-line">
+      <div>
+        <div class="card-label mb-0.5">Assets</div>
+        <div class="num text-sm">{{ macros.peso(total_assets) }}</div>
+      </div>
+      <div>
+        <div class="card-label mb-0.5">Liabilities</div>
+        <div class="num text-sm">{{ macros.peso(total_liabilities) }}</div>
+      </div>
+    </div>
+  </div>
   {% if period_warnings %}
     <div class="section">
+      <span class="entry-tab entry-tab-rust">Warning</span>
       <div class="section-title">
         Cash flow warnings
         <span class="pill">{{ period_warnings|length }} period{{ 's' if period_warnings|length != 1 else '' }}</span>
@@ -26,8 +42,9 @@
   {% endif %}
   {% if next_payout_period %}
     <div class="section">
+      <span class="entry-tab entry-tab-gold">Upcoming</span>
       <div class="section-title">
-        Upcoming — {{ next_payout_period.label }}<span class="pill">{{ upcoming_expenses|length }} due</span>
+        {{ next_payout_period.label }}<span class="pill">{{ upcoming_expenses|length }} due</span>
       </div>
       <div class="table-wrap">
         <table class="led">
@@ -66,21 +83,8 @@
       </div>
     </div>
   {% endif %}
-  <div class="flex flex-wrap gap-4 mb-5">
-    <div class="card flex-1 min-w-[10rem]">
-      <div class="card-label">Total assets</div>
-      <div class="card-value">{{ macros.peso(total_assets) }}</div>
-    </div>
-    <div class="card flex-1 min-w-[10rem]">
-      <div class="card-label">Total liabilities</div>
-      <div class="card-value">{{ macros.peso(total_liabilities) }}</div>
-    </div>
-    <div class="card flex-1 min-w-[10rem]">
-      <div class="card-label">Net worth</div>
-      <div class="card-value {{ 'card-value-neg' if net_worth < 0 else '' }}">{{ macros.peso(net_worth) }}</div>
-    </div>
-  </div>
   <div class="section">
+    <span class="entry-tab">Goals</span>
     <div class="section-title">Goals<span class="pill">{{ goals|length }} total</span></div>
     <div class="table-wrap">
       <table class="led">
@@ -116,6 +120,7 @@
     </div>
   </div>
   <div class="section">
+    <span class="entry-tab">Credit</span>
     <div class="section-title">Credit<span class="pill">{{ credit_lines|length }} total</span></div>
     <div class="table-wrap">
       <table class="led">

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -28,15 +28,22 @@
         Cash flow warnings
         <span class="pill">{{ period_warnings|length }} period{{ 's' if period_warnings|length != 1 else '' }}</span>
       </div>
-      <div class="warn-banner">
-        {% for entry in period_warnings %}
-          {% for name in entry.warnings.unfunded_channels %}
-            <span class="warn-pill warn-red">{{ name }} goes negative on the {{ entry.period.label }}</span>
+      <div class="warn-banner-wrap" id="overview-warn-wrap">
+        <div class="warn-banner">
+          {% for entry in period_warnings %}
+            {% for name in entry.warnings.unfunded_channels %}
+              <span class="warn-pill warn-red">{{ name }} goes negative on the {{ entry.period.label }}</span>
+            {% endfor %}
+            {% for name in entry.warnings.underfunded_goals %}
+              <span class="warn-pill warn-amber">{{ name }} isn't fully funded on the {{ entry.period.label }}</span>
+            {% endfor %}
           {% endfor %}
-          {% for name in entry.warnings.underfunded_goals %}
-            <span class="warn-pill warn-amber">{{ name }} isn't fully funded on the {{ entry.period.label }}</span>
-          {% endfor %}
-        {% endfor %}
+        </div>
+        <div class="warn-fade"></div>
+        <button type="button"
+                class="warn-toggle"
+                aria-label="Show all warnings"
+                onclick="toggleWarnBanner('overview-warn-wrap', this)">&hellip;</button>
       </div>
     </div>
   {% endif %}
@@ -50,7 +57,7 @@
         <table class="led">
           <colgroup>
             <col class="min-w-28">
-            <col class="w-40">
+            <col class="w-36">
             <col class="w-32">
           </colgroup>
           <thead>

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -51,7 +51,8 @@ def test_overview_upcoming_expenses_banner(client: TestClient) -> None:
 
     response = client.get("/overview")
     assert response.status_code == 200
-    assert "Upcoming — 15th" in response.text
+    assert "Upcoming" in response.text
+    assert "15th" in response.text
     assert "Meralco" in response.text
     assert "2,500.50" in response.text
 


### PR DESCRIPTION
## Summary
Implements the approved "Bound Ledger" pitch for #46 across the whole app (light + dark mode, desktop + mobile):

- **Rail becomes a book spine** — deep cover-green, stitched binding texture, brass corner mark (replacing the wordmark removed in #45). A light/dark toggle lives at the bottom of the rail, persisted to `localStorage`, defaulting to `prefers-color-scheme`.
- **Ruled paper + entry tabs** — every page carries faint ruled lines; cards/sections gained a small colored `entry-tab` (Balance/Warning/Upcoming/Goals/Credit/Channels/etc.) naming what they are before you read the number.
- **Warning pills** get a rubber-stamp look (double ring, slight tilt that straightens on hover).
- **Mobile gets a real bottom tab bar** (Overview/Expenses/Cash Flow/Goals + a "More" sheet for Credit/Assets/Account/theme toggle/Log out) instead of squeezing the desktop rail down to icons.
- **Full dark-mode token set** — every color token got a dark counterpart (media-query default + explicit `data-theme` overrides for the manual toggle), including the Cash Flow canvas's grid-line colors, which were hardcoded and would've gone invisible in dark mode. Added `-strong` fill tokens for solid buttons/badges carrying fixed white text, since the regular accent/gold/rust tokens brighten in dark mode for foreground legibility — reusing them as button fills would've broken contrast.
- **Follow-up polish from review**: cash-flow warning banners now collapse to one line with a fade + expand toggle instead of wrapping across several rows; ledger tables (`Goals`/`Credit`/`Assets`/`Expenses`/`Overview`) no longer stretch to fill the section, and channel columns were narrowed to remove dead space between columns.

## Known issue found during QA (not fixed here)
Peso-sign (₱) figures rendered bold/large (e.g. the Overview net-worth hero) show a stray horizontal line artifact in Chrome on this machine. Confirmed via isolated DOM tests that it's font/glyph-rendering related, reproduces even at the original (pre-redesign) `.card-value` size, and is unrelated to this redesign's CSS — filing as its own issue rather than blocking this PR.

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 120 passed
- [x] Manually verified every page (Overview, Expenses, Cash Flow, Goals, Credit, Assets, Account, Login) in both light and dark mode via `docker compose up --build`
- [x] Verified the mobile bottom tab bar and "More" sheet render and function correctly at a phone-width viewport