### PR TITLE
(feat) Move expense filter inline with the section title on large screens

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -171,7 +171,7 @@
     @apply border-l-[3px] border-l-accent;
   }
   .section-title {
-    @apply font-semibold text-base mb-3 flex items-center justify-between;
+    @apply font-semibold text-base mb-3 flex items-center justify-between flex-wrap gap-2;
   }
   .pill {
     @apply text-[10.5px] font-semibold px-2.5 py-0.5 rounded-full bg-accent/10 text-accent tracking-wide;

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -380,18 +380,18 @@
   <div class="section{{ ' opacity-50 pointer-events-none' if not channels or not payout_periods else (' section-onboarding-active' if onboarding_step == 3 else '') }}">
     <div class="section-title">
       <span>Recurring expenses<span class="pill">{{ expenses|length }} items</span></span>
+      <input id="expense-search"
+             class="field w-full sm:w-48"
+             type="search"
+             name="q"
+             value="{{ q }}"
+             placeholder="Filter by name&hellip;"
+             hx-preserve
+             hx-get="/expenses"
+             hx-trigger="keyup changed delay:300ms, search"
+             hx-target="#expenses-page"
+             hx-swap="outerHTML">
     </div>
-    <input id="expense-search"
-           class="field w-48 mb-3"
-           type="search"
-           name="q"
-           value="{{ q }}"
-           placeholder="Filter by name&hellip;"
-           hx-preserve
-           hx-get="/expenses"
-           hx-trigger="keyup changed delay:300ms, search"
-           hx-target="#expenses-page"
-           hx-swap="outerHTML">
     <form id="add-expense-form"
           hx-post="/expenses"
           hx-target="#expenses-page"


### PR DESCRIPTION
## Summary
Addresses #62. `#expense-search` was a block-level sibling below `.section-title` on the Expenses page's "Recurring expenses" section, so it always stacked below the title even on wide viewports.

- Moved `#expense-search` to be a second child inside `.section-title`, alongside the existing title span — `.section-title` already had `flex items-center justify-between`, so this places the search box flush right on large screens for free.
- Added `flex-wrap gap-2` to `.section-title` (matching `.page-head`'s existing `flex-wrap` responsive pattern elsewhere in this app) so on narrow screens the input wraps to its own full-width line instead of squeezing next to the title.
- Input's own classes changed from `w-48 mb-3` to `w-full sm:w-48` (full-width when wrapped on mobile, compact inline width on `sm:` and up; `mb-3` dropped since it's now a flex child of `.section-title`, which already has its own `mb-3`).
- No behavior change — all `hx-get`/`hx-trigger`/`hx-target`/`hx-swap`/`hx-preserve` attributes preserved exactly.

## Test plan
- [x] `ruff format` / `ruff check` clean
- [x] `pytest` — 153/153 passing
- [ ] `mypy`/`djlint` blocked locally by a Windows Device Guard policy in this environment (unrelated to the change — a template/CSS-only diff, no type or Jinja-lint-relevant surface); worth a normal CI run to confirm
- [ ] No live browser/visual check performed (a coordinating session has a stack running on the shared dev machine's port 8000 already, so Docker wasn't started here to avoid conflicting with it) — recommend a quick visual pass before merge