### PR TITLE
(fix) Sync nav rail label fade with the rail's own expand/collapse transition

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -75,7 +75,7 @@
     @apply flex items-center justify-between px-5 pb-4 mb-3 border-b border-line;
   }
   .rail-brand {
-    @apply flex items-center gap-2.5 min-w-0;
+    @apply flex items-center gap-2.5 min-w-0 transition-opacity duration-150;
   }
   .rail-greeting {
     @apply font-serif font-semibold text-sm text-ink truncate;
@@ -88,6 +88,13 @@
   }
   .tab-active {
     @apply bg-accent/10 text-accent border-l-accent font-semibold;
+  }
+  .tab-label {
+    /* Faded out (not display:none'd) via JS *before* the rail's own 200ms
+       width transition starts, and only removed from layout after it -- see
+       applyCollapsed() in base.html. Keeps label text from instantly
+       reflowing/wrapping while the rail is still animating narrower. */
+    @apply transition-opacity duration-150;
   }
 
   /* Bottom tab bar -- the mobile replacement for .rail. Hidden by default;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -278,9 +278,27 @@
         railHead.classList.toggle("flex-col", collapsed);
         railHead.classList.toggle("gap-2", collapsed);
         railHead.classList.toggle("justify-between", !collapsed);
-        railBrand.style.display = collapsed ? "none" : "";
-        labels().forEach((el) => { el.style.display = collapsed ? "none" : ""; });
         icon.textContent = collapsed ? "›" : "‹";
+
+        // Fade .tab-label/.rail-brand out *before* hiding them, and only
+        // hide once faded -- instantly toggling `display` here (the old
+        // behavior) snapped label text in/out of layout while .rail's own
+        // 200ms width transition was still running, causing a flicker as
+        // text reflowed/wrapped mid-animation.
+        const fadeTargets = [railBrand, ...labels()];
+        if (collapsed) {
+          fadeTargets.forEach((el) => el.classList.add("opacity-0"));
+          setTimeout(() => {
+            fadeTargets.forEach((el) => { el.style.display = "none"; });
+          }, 150);
+        } else {
+          fadeTargets.forEach((el) => { el.style.display = ""; });
+          // Force a reflow so the browser registers `display` being restored
+          // before opacity changes -- otherwise there's nothing to fade in
+          // from and the label just pops back in instantly.
+          void rail.offsetWidth;
+          fadeTargets.forEach((el) => el.classList.remove("opacity-0"));
+        }
       }
 
       const stored = localStorage.getItem("railCollapsed") === "true";


### PR DESCRIPTION
## Summary
Addresses #63. Expanding/collapsing the left rail nav made each tab's label flicker because `.rail`'s width change is a 200ms CSS transition, but `.tab-label`/`#rail-brand` visibility toggled instantly via `style.display` in the same `applyCollapsed()` call — labels snapped in/out of layout while the rail was still animating, causing text to reflow/wrap mid-transition.

## Change
- `app/static/css/input.css`: added `transition-opacity duration-150` to `.tab-label` (new class) and `.rail-brand`.
- `app/templates/base.html`'s `applyCollapsed()`: fades labels out (opacity) before removing them from layout via a 150ms `setTimeout` (mirrors the existing `setTimeout(updateWarnOverflow, 220)` pattern already in this handler); on expand, restores `display` first, forces a reflow, then fades opacity back in so there's something to transition from.

## Test plan
- [x] `ruff format`/`ruff check` clean
- [x] `pytest` — 153 passed (mypy/djlint blocked locally by this machine's Device Guard policy for both `.exe` and `python -m` invocation — pre-existing environment issue, unrelated to this change; this is a pure CSS+JS change with zero Python touched)
- [ ] Live visual confirmation that the flicker is actually gone — I implemented this from source reasoning (couldn't run the app myself, a live stack was already occupying the dev ports). Please eyeball the collapse/expand animation before merging.