### PR TITLE
(fix) Theme select dropdown option lists to match the dark theme

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -67,6 +67,22 @@
   --color-rust-soft: rgba(229, 115, 115, 0.16);
 }
 
+/* Tells the browser which native form-control chrome to use -- without this,
+   a <select>'s open option-list popup always renders with light/OS-default
+   styling regardless of this app's own dark theme, since that popup is
+   native browser UI, not something our CSS paints. Mirrors the same
+   system-preference-vs-manual-override precedence as the palette tokens
+   above: default to following the OS, but let data-theme win either way. */
+:root {
+  color-scheme: light dark;
+}
+:root[data-theme="dark"] {
+  color-scheme: dark;
+}
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
 @layer components {
   .rail {
     @apply w-52 shrink-0 bg-card border-r border-line flex flex-col gap-1 py-5 transition-[width] duration-200 ease-in-out;
@@ -257,6 +273,15 @@
   }
   .field {
     @apply w-full min-w-0 rounded border border-line px-2.5 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-accent;
+  }
+  /* Belt-and-suspenders alongside the color-scheme declarations above --
+     color-scheme drives the popup's own chrome (background, scrollbar), but
+     browser support/behavior for that on the *option rows themselves*
+     varies, so pin their background/text explicitly too. */
+  .field option,
+  .field optgroup {
+    background-color: var(--color-card);
+    color: var(--color-ink);
   }
   .field-mono {
     @apply font-mono text-right;


### PR DESCRIPTION
## Summary
Addresses #64. Root cause: native `<select>` option-list popups render with browser/OS-default (light) styling regardless of this app's dark theme, since that popup is native browser chrome, not something app CSS paints directly.

Originally filed against the timezone dropdown specifically, but a follow-up investigation on the issue confirmed every `<select class="field">` in the app has the identical problem (currency, channel type, receiving-channel pickers, etc.) — timezone is just the most visible instance due to its ~400 options. This fix applies once via the shared `.field` class, so it covers every select automatically.

## What changed
`app/static/css/input.css`:
1. **`color-scheme` declarations** (`light dark` by default, overridden to `dark`/`light` under `data-theme`, mirroring the exact precedence pattern the palette tokens already use for system-preference vs. manual-toggle). This is the browser-standard mechanism for telling native form controls which chrome to render with — it's what actually influences the popup's own background/scrollbar, which plain CSS colors can't reach.
2. **`.field option`/`.field optgroup` background/color** as a belt-and-suspenders fallback, since browser support for extending `color-scheme` to individual option-row styling varies.

I deviated slightly from "just add option/optgroup styling" (the originally-scoped fix direction) once I found this app sets no `color-scheme` anywhere — it's the more complete, standard fix for exactly this problem and is still a small, declarative CSS-only addition (not a custom listbox, which stays out of scope per the issue).

## Caveat
Still not a 100% guaranteed pixel-perfect result across every browser/OS combination (native popup rendering has real platform variance) — but this should fix the reported "white background, dark text" clash in the common case (confirmed Chrome/Windows per the original report).

## Verification
- `ruff format`/`ruff check`: clean
- `mypy`: could not run — Device Guard on this machine blocks mypy's compiled module outright (independent of this change; it's CSS-only, zero Python touched)
- `pytest`: 152/153 passing; the 1 failure (`test_update_profile_persists_all_fields`) is a pre-existing local-environment gap (this Windows venv lacks the `tzdata` package, unrelated to this change or to `pyproject.toml`)
- `djlint`: skipped (needs Docker, unavailable in this worktree — CSS-only change, unlikely to apply anyway)
- **Not yet visually verified in a browser** — this worktree couldn't run the app (a live stack was already using the host's ports). Needs a live check in both light and dark mode before merging.