### PR TITLE
(fix) Smooth the reveal when opening an "Add" row

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -417,6 +417,9 @@
         if (visible) {
           const toSelect = row.querySelector('select[name="to_channel_id"]');
           if (toSelect) prefillTransferAmount(toSelect);
+          // Bring the newly-revealed row into view smoothly instead of
+          // letting the page's height jump and the scrollbar pop abruptly.
+          row.scrollIntoView({ behavior: "smooth", block: "nearest" });
         }
       }
 


### PR DESCRIPTION
## Summary
Addresses #61. Clicking an "Add" trigger (`toggleAddRow()` in `app/templates/base.html`) reveals a hidden row/form by instantly toggling `hidden`/`flex` with no transition, which can push content past viewport height and pop a scrollbar abruptly.

A prior investigation on #61 couldn't confirm exact repro steps or a narrower root cause — the main content region is intentionally `overflow-y-auto` for genuinely long content, so this may be "correct behavior that feels abrupt" rather than a distinct defect. This PR is a best-effort smoothing fix rather than an attempt to eliminate scrolling outright.

## Change
In `toggleAddRow()`, after revealing a row, smoothly scroll it into view: `row.scrollIntoView({ behavior: "smooth", block: "nearest" })`. Makes the reveal feel intentional instead of an abrupt jump. Only fires on open (not on `cancelAddRow`).

## Test plan
- [x] `ruff format` / `ruff check` pass
- [x] `pytest` — 153 passed
- [ ] mypy couldn't run in this environment (Device Guard blocks mypy's compiled DLL here) — this change is JS-only inside a template, no Python touched, so low risk
- [ ] **Live visual/behavioral confirmation still needed** — this worktree has no access to the already-running dev stack (port conflict avoidance), so the actual scroll smoothness hasn't been eyeballed in a browser yet