### PR TITLE
(feat) Add a generic loading state for htmx requests

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -262,6 +262,21 @@
     @apply font-mono text-right;
   }
 
+  /* htmx adds this class to whichever element triggered a request (or its
+     hx-indicator, if one's set) for the request's duration -- no per-element
+     opt-in needed, so this alone covers every hx-get/post/delete trigger
+     app-wide, including the standalone login/signup pages. */
+  .htmx-request {
+    @apply opacity-60 pointer-events-none;
+  }
+  .add-btn.htmx-request::after,
+  .btn-secondary.htmx-request::after,
+  .provider-btn.htmx-request::after,
+  .icon-btn.htmx-request::after {
+    content: "";
+    @apply inline-block w-3 h-3 ml-1.5 rounded-full border-2 border-current border-t-transparent align-[-2px] animate-spin;
+  }
+
   .badge {
     @apply inline-flex items-center justify-center rounded-full text-white text-[10px] font-bold shrink-0 overflow-hidden leading-none;
   }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -235,6 +235,22 @@
         evt.detail.headers["X-CSRF-Token"] = csrfToken;
       });
 
+      // htmx's own .htmx-request loading-state class only lands on the
+      // element carrying the hx-* attributes -- for the add/edit forms all
+      // over this app whose submit button lives outside the <form> itself
+      // (via a form="..." attribute), that's an invisible <form>, not the
+      // visible button the user actually clicked. Mirror the class onto any
+      // externally-associated [form="..."] elements too, so the CSS
+      // treatment in input.css reaches what the user is looking at.
+      function syncFormIndicator(evt, add) {
+        const el = evt.detail.elt;
+        if (el.tagName === "FORM" && el.id) {
+          document.querySelectorAll(`[form="${el.id}"]`).forEach((btn) => btn.classList.toggle("htmx-request", add));
+        }
+      }
+      document.body.addEventListener("htmx:beforeRequest", (evt) => syncFormIndicator(evt, true));
+      document.body.addEventListener("htmx:afterRequest", (evt) => syncFormIndicator(evt, false));
+
       const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
       const lightIcons = document.querySelectorAll(".js-theme-icon-light");
       const darkIcons = document.querySelectorAll(".js-theme-icon-dark");


### PR DESCRIPTION
## Summary
Addresses #60 — no visual feedback existed between clicking something that triggers an htmx request and the response arriving.

- Added a `.htmx-request` CSS rule in `app/static/css/input.css` (dims + disables pointer events on the triggering element, plus a small `::after` spinner on `.add-btn`/`.btn-secondary`/`.provider-btn`/`.icon-btn`).
- **Important finding**: most of this app's add/edit forms have their submit button *outside* the `<form>` element (linked via a `form="..."` attribute) — htmx's built-in indicator class only ever lands on the `<form>` itself in that pattern, which is invisible, not the button the user actually clicked. Added a small global listener in `app/templates/base.html` (`htmx:beforeRequest`/`htmx:afterRequest`) that mirrors `.htmx-request` onto any `[form="..."]`-associated elements too, so the CSS treatment actually reaches what's on screen for the add/edit case, not just deletes and the search box (which already had hx-* directly on themselves and didn't need this).
- `login.html`/`signup.html` (standalone, don't extend `base.html`) get the CSS treatment for free via the shared stylesheet; `signup.html`'s invite-key check already has `hx-get` directly on the input, so no JS bridge needed there.

## What I verified
- `ruff format .` / `ruff check .` — clean
- `mypy app tests` — could not run; blocked by a Windows "Application Control policy" (Device Guard) on this machine that blocks mypy's compiled mypyc DLL regardless of invocation method. Pre-existing environment limitation, unrelated to this change (no Python files touched — this diff is CSS + template JS only).
- `pytest -q` — 152 passed, 1 failed (`test_update_profile_persists_all_fields`) — confirmed the failure is the known pre-existing Windows-tzdata gap (`zoneinfo.available_timezones()` returns empty without the `tzdata` package installed locally; works fine in Docker/CI on Linux), not a regression from this change.
- Could not run `docker compose` or preview live (a coordinator session already had a stack up on the shared host ports) — **live verification with network throttling still needs to happen** before merging, especially to confirm the spinner/dim treatment looks right and the form-indicator bridge actually fires correctly in a real browser.