### PR TITLE
(fix) Cancel pending nav-label hide timeout on rapid rail toggling

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -272,7 +272,16 @@
       const icon = document.getElementById("collapse-icon");
       const labels = () => document.querySelectorAll(".tab-label");
 
-      function applyCollapsed(collapsed) {
+      // Tracks the in-flight "hide after fade" timeout so a second toggle
+      // fired before the first one finishes can cancel it -- otherwise the
+      // stale timeout fires *after* the second toggle has already set the
+      // opposite state, forcing display:none back on regardless of the
+      // current (correct) opacity/collapsed state. Reproduces by toggling
+      // twice within 150ms: labels end up permanently hidden even though
+      // the rail is expanded.
+      let fadeHideTimeout = null;
+
+      function applyCollapsed(collapsed, { animate = true } = {}) {
         rail.classList.toggle("w-52", !collapsed);
         rail.classList.toggle("w-16", collapsed);
         railHead.classList.toggle("flex-col", collapsed);
@@ -280,29 +289,42 @@
         railHead.classList.toggle("justify-between", !collapsed);
         icon.textContent = collapsed ? "›" : "‹";
 
+        clearTimeout(fadeHideTimeout);
+
         // Fade .tab-label/.rail-brand out *before* hiding them, and only
         // hide once faded -- instantly toggling `display` here (the old
         // behavior) snapped label text in/out of layout while .rail's own
         // 200ms width transition was still running, causing a flicker as
-        // text reflowed/wrapped mid-animation.
+        // text reflowed/wrapped mid-animation. Skipped on initial page load
+        // (animate=false) so a collapsed-by-default rail doesn't flash
+        // labels visible-then-fading before its first paint.
         const fadeTargets = [railBrand, ...labels()];
         if (collapsed) {
-          fadeTargets.forEach((el) => el.classList.add("opacity-0"));
-          setTimeout(() => {
-            fadeTargets.forEach((el) => { el.style.display = "none"; });
-          }, 150);
+          if (animate) {
+            fadeTargets.forEach((el) => el.classList.add("opacity-0"));
+            fadeHideTimeout = setTimeout(() => {
+              fadeTargets.forEach((el) => { el.style.display = "none"; });
+            }, 150);
+          } else {
+            fadeTargets.forEach((el) => {
+              el.classList.add("opacity-0");
+              el.style.display = "none";
+            });
+          }
         } else {
           fadeTargets.forEach((el) => { el.style.display = ""; });
-          // Force a reflow so the browser registers `display` being restored
-          // before opacity changes -- otherwise there's nothing to fade in
-          // from and the label just pops back in instantly.
-          void rail.offsetWidth;
+          if (animate) {
+            // Force a reflow so the browser registers `display` being
+            // restored before opacity changes -- otherwise there's nothing
+            // to fade in from and the label just pops back in instantly.
+            void rail.offsetWidth;
+          }
           fadeTargets.forEach((el) => el.classList.remove("opacity-0"));
         }
       }
 
       const stored = localStorage.getItem("railCollapsed") === "true";
-      applyCollapsed(stored);
+      applyCollapsed(stored, { animate: false });
 
       document.getElementById("collapse-toggle").addEventListener("click", () => {
         const collapsed = !rail.classList.contains("w-16");


### PR DESCRIPTION
## Summary
Follow-up to #88 (merged) — found while live-testing that PR: toggling the rail collapse/expand twice quickly leaves the nav labels permanently invisible (`display:none`) even though the rail ends up expanded and everything else looks correct.

## Root cause
`applyCollapsed()`'s collapse path fades labels out via opacity, then schedules a `setTimeout(..., 150)` to set `display:none` once the fade finishes. If the rail is toggled again before that timeout fires, the *stale* timeout still fires 150ms after the *first* click — setting `display:none` on all label elements regardless of what the second toggle just set, permanently hiding them until a page reload.

## Fix
Track the pending timeout in a closure variable and `clearTimeout()` it at the start of every `applyCollapsed()` call. Also skips the fade animation on the initial page-load call (`animate: false`) so a collapsed-by-default rail doesn't flash labels visible-then-fading before first paint — the original code should always have been instant there since nothing was previously showing.

## Verification
- `ruff format`/`ruff check`/`mypy app tests`/`pytest -q` (153/153) all clean.
- `djlint --check` clean via Docker.
- Manually reproduced the original bug live (rapid toggle → labels stuck `display:none` while rail shows expanded), confirmed this fix resolves it, and confirmed normal single-toggle behavior (the actual flicker fix from #88) still works correctly.