### PR TITLE
(fix) Widen actions column to stop add-row scrollbar (real fix for #61)

### DIFF
--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -23,7 +23,7 @@
           <col class="min-w-28">
           <col class="w-40">
           <col class="w-32">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -21,7 +21,7 @@
           <col class="w-28">
           <col class="w-28">
           <col class="w-44">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -243,7 +243,7 @@
           <col class="w-24">
           <col class="w-32">
           <col class="min-w-28">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>
@@ -404,7 +404,7 @@
           <col class="w-24">
           <col class="w-40">
           <col class="w-24">
-          <col class="w-20">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -22,7 +22,7 @@
           <col class="w-28">
           <col class="w-20">
           <col class="w-56">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
Supersedes #90, which added `scrollIntoView` smoothing based on an incorrect assumption (page-level vertical scroll). The user clarified the actual bug: clicking "+ Add" makes a **horizontal** scrollbar appear right at the Add/Cancel buttons themselves, on Goals/Credit/Assets/Payout periods/Expenses.

## Root cause
Every `.led` table (`table-layout: fixed`) sizes its actions column via `colgroup` for the read-only rows' icon-only edit/delete buttons (`w-20`/`w-28`, 80-112px). The hidden add-row's actions cell instead holds two text-labeled buttons (`add-btn` "Add" + `btn-secondary` "Cancel", `gap-2`) which need ~126px. That's wider than the fixed column, and since content can't shrink further, the table's own `min-w-max` grows the whole table past its `.table-wrap` container -- popping a horizontal scrollbar exactly at the buttons the moment "+ Add" is clicked.

Confirmed via live measurement in the running app: `add-goal-row`'s actions `<td>` had `offsetWidth: 112` but `scrollWidth: 126` -- a 14px overflow, matching the wrapper's own overflow exactly.

## Fix
Widened the actions column to `w-36` (144px, comfortable margin) in every affected table: `goals_page.html`, `credit_page.html`, `assets_page.html`, and both the payout-periods and expenses tables in `expenses_page.html`. (The Channels add-row is a flex `<div>`, not a table row, so it wraps naturally and was never affected.)

Read-only rows are unaffected -- `.led-actions` icon buttons are absolutely positioned flush-right regardless of column width, so they don't visually shift.

## Verification
- `ruff format`/`ruff check`/`mypy app tests`/`pytest -q` (153/153) all clean.
- `djlint --check` clean via Docker.
- Live in the running app: triggered every affected add-row (Goals, Credit, Assets, Channels, Payout periods, Expenses) and measured `table-wrap.scrollWidth - table-wrap.clientWidth` -- **0px overflow** on all six, down from a nonzero overflow beforehand. Visual screenshot confirms no scrollbar and comfortable button spacing.

Recommend closing #90 in favor of this PR once merged -- its fix doesn't address the actual reported bug.