### PR TITLE
(fix) Widen actions column to stop add-row scrollbar (real fix for #61) [v2]

### DIFF
--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -23,7 +23,7 @@
           <col class="min-w-28">
           <col class="w-40">
           <col class="w-32">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -21,7 +21,7 @@
           <col class="w-28">
           <col class="w-28">
           <col class="w-44">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -243,7 +243,7 @@
           <col class="w-24">
           <col class="w-32">
           <col class="min-w-28">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>
@@ -404,7 +404,7 @@
           <col class="w-24">
           <col class="w-40">
           <col class="w-24">
-          <col class="w-20">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -22,7 +22,7 @@
           <col class="w-28">
           <col class="w-20">
           <col class="w-56">
-          <col class="w-28">
+          <col class="w-36">
         </colgroup>
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
Re-creation of #93, which GitHub's "stacked PR" async merge marked as MERGED but never actually landed on \`dev\` (the squash commit exists in the repo but \`dev\`'s ref was never updated to include it -- confirmed via \`gh api repos/.../branches/dev\`). Same fix, fresh branch off current \`dev\` tip to sidestep whatever confused the stack detection on the old branch.

## Summary of the actual fix
Every \`.led\` table's actions column was sized for the read-only rows' icon-only edit/delete buttons (w-20/w-28, 80-112px). The hidden add-row's Add+Cancel button pair needs ~126px -- with \`table-layout: fixed\`, that mismatch forces the table wider than its container, popping a horizontal scrollbar right at the buttons the moment "+ Add" is clicked. Widened the actions column to w-36 in \`goals_page.html\`, \`credit_page.html\`, \`assets_page.html\`, and both tables in \`expenses_page.html\` (payout periods, expenses).

## Verification
- Same commit as #93, cherry-picked cleanly onto current \`dev\` with no conflicts.
- \`ruff format\`/\`ruff check\`/\`mypy app tests\`/\`pytest -q\` (153/153) all clean.
- Original PR (#93) already had this live-verified in the running app (0px overflow on all six add-rows) before the stuck-merge issue.

Closes #93's underlying goal -- that PR should be closed as not-actually-merged once this one lands.