### PR TITLE
(chore) Bump version to 0.1.0-beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finance-tracker"
-version = "0.1.0"
+version = "0.1.0-beta"
 description = "Personal finance tracker (FastAPI + HTMX + Postgres)"
 requires-python = ">=3.12,<4.0"
 dependencies = [


### PR DESCRIPTION
Bumps `pyproject.toml`'s version to `0.1.0-beta` per request, to mark the current pre-release state now that the multi-user auth / OAuth / Cash Flow canvas work has landed on `main` (see the incident writeup in issue comments around PR #93 for how that happened). No functional changes.