### PR TITLE
(fix) memoize payout period carry-in to avoid exponential recomputation

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -878,50 +878,73 @@ def preview_canvas(
 # --- Channel balances -----------------------------------------------------------
 
 
+def _all_channel_balances(
+    db: Session, user_id: int
+) -> tuple[dict[int, dict[int, float]], dict[int, list[tuple[models.Channel, float]]]]:
+    """Every payout period's carry-in and channel balances, computed once per
+    request in a single display_order pass -- each period's ending balances
+    become the next period's carry-in, fed forward directly, rather than each
+    period independently re-deriving every prior period's full balance
+    calculation (which was exponential: computing period k re-triggered a
+    fresh computation of periods 0..k-1, each of which re-triggered periods
+    0..k-2, and so on). This is the O(n) replacement; callers that need one
+    period's data should index into the returned dicts rather than calling
+    this per period in a loop."""
+    channels = list_channels(db, user_id)
+    periods = list_payout_periods(db, user_id)
+    all_expenses = list_expenses(db, user_id)
+
+    carry_in_by_period: dict[int, dict[int, float]] = {}
+    balances_by_period: dict[int, list[tuple[models.Channel, float]]] = {}
+    carry: dict[int, float] = {}
+    for period in periods:
+        carry_in_by_period[period.id] = carry
+        expenses = [e for e in all_expenses if e.payout_period_id == period.id]
+        transfers = list_transfers(db, period.id, user_id)
+        goal_contributions = list_goal_contributions(db, period.id, user_id)
+
+        balances: list[tuple[models.Channel, float]] = []
+        for channel in channels:
+            net = carry.get(channel.id, 0.0)
+            if period.receiving_channel_id == channel.id:
+                net += float(period.income_amount)
+            net += sum(float(t.amount) for t in transfers if t.to_channel_id == channel.id)
+            net -= sum(float(t.amount) for t in transfers if t.from_channel_id == channel.id)
+            net -= sum(float(e.amount) for e in expenses if e.channel_id == channel.id)
+            net -= sum(float(gc.amount) for gc in goal_contributions if gc.channel_id == channel.id)
+            balances.append((channel, net))
+        balances_by_period[period.id] = balances
+        carry = {c.id: net for c, net in balances}
+
+    return carry_in_by_period, balances_by_period
+
+
 def _carry_in_for_period(db: Session, payout_period_id: int, user_id: int) -> dict[int, float]:
     """Each channel's ending balance from the payout period before this one (in
-    display_order), so a month's leftover cash chains forward period to period."""
-    carry: dict[int, float] = {}
-    for period in list_payout_periods(db, user_id):
-        if period.id == payout_period_id:
-            break
-        carry = {c.id: net for c, net in channel_balances(db, period.id, user_id)}
-    return carry
+    display_order), so a month's leftover cash chains forward period to period.
+    Single-period convenience wrapper around `_all_channel_balances` -- don't
+    call this in a per-period loop, call `_all_channel_balances` once instead."""
+    carry_in_by_period, _ = _all_channel_balances(db, user_id)
+    return carry_in_by_period.get(payout_period_id, {})
 
 
 def channel_balances(
     db: Session, payout_period_id: int, user_id: int
 ) -> list[tuple[models.Channel, float]]:
-    carry_in = _carry_in_for_period(db, payout_period_id, user_id)
-    payout_period = _owned(db, models.PayoutPeriod, payout_period_id, user_id)
-    channels = list_channels(db, user_id)
-    expenses = [e for e in list_expenses(db, user_id) if e.payout_period_id == payout_period_id]
-    transfers = list_transfers(db, payout_period_id, user_id)
-    goal_contributions = list_goal_contributions(db, payout_period_id, user_id)
-
-    balances = []
-    for channel in channels:
-        net = carry_in.get(channel.id, 0.0)
-        if payout_period is not None and payout_period.receiving_channel_id == channel.id:
-            net += float(payout_period.income_amount)
-        net += sum(float(t.amount) for t in transfers if t.to_channel_id == channel.id)
-        net -= sum(float(t.amount) for t in transfers if t.from_channel_id == channel.id)
-        net -= sum(float(e.amount) for e in expenses if e.channel_id == channel.id)
-        net -= sum(float(gc.amount) for gc in goal_contributions if gc.channel_id == channel.id)
-        balances.append((channel, net))
-    return balances
+    """Single-period convenience wrapper around `_all_channel_balances` -- don't
+    call this in a per-period loop (each call recomputes every period), call
+    `_all_channel_balances` once instead and index into its result."""
+    _, balances_by_period = _all_channel_balances(db, user_id)
+    return balances_by_period.get(payout_period_id, [])
 
 
-def cashflow_warnings(db: Session, payout_period_id: int, user_id: int) -> dict[str, list[str]]:
-    unfunded_channels = [
-        c.name for c, net in channel_balances(db, payout_period_id, user_id) if net < 0
-    ]
-
-    goals = list_goals(db, user_id)
-    payout_period_count = len(list_payout_periods(db, user_id))
-    contributed = {
-        c.goal_id: float(c.amount) for c in list_goal_contributions(db, payout_period_id, user_id)
-    }
+def _cashflow_warnings_from_balances(
+    balances: list[tuple[models.Channel, float]],
+    goals: list[models.Goal],
+    payout_period_count: int,
+    contributed: dict[int, float],
+) -> dict[str, list[str]]:
+    unfunded_channels = [c.name for c, net in balances if net < 0]
     underfunded_goals = [
         g.name
         for g in goals
@@ -930,10 +953,30 @@ def cashflow_warnings(db: Session, payout_period_id: int, user_id: int) -> dict[
     return {"unfunded_channels": unfunded_channels, "underfunded_goals": underfunded_goals}
 
 
+def cashflow_warnings(db: Session, payout_period_id: int, user_id: int) -> dict[str, list[str]]:
+    balances = channel_balances(db, payout_period_id, user_id)
+    goals = list_goals(db, user_id)
+    payout_period_count = len(list_payout_periods(db, user_id))
+    contributed = {
+        c.goal_id: float(c.amount) for c in list_goal_contributions(db, payout_period_id, user_id)
+    }
+    return _cashflow_warnings_from_balances(balances, goals, payout_period_count, contributed)
+
+
 def overview_warnings(db: Session, user_id: int) -> list[dict]:
+    periods = list_payout_periods(db, user_id)
+    _, balances_by_period = _all_channel_balances(db, user_id)
+    goals = list_goals(db, user_id)
+    payout_period_count = len(periods)
+
     entries = []
-    for period in list_payout_periods(db, user_id):
-        warnings = cashflow_warnings(db, period.id, user_id)
+    for period in periods:
+        contributed = {
+            c.goal_id: float(c.amount) for c in list_goal_contributions(db, period.id, user_id)
+        }
+        warnings = _cashflow_warnings_from_balances(
+            balances_by_period.get(period.id, []), goals, payout_period_count, contributed
+        )
         if warnings["unfunded_channels"] or warnings["underfunded_goals"]:
             entries.append({"period": period, "warnings": warnings})
     return entries
@@ -1319,12 +1362,19 @@ def cashflow_page_data(db: Session, user_id: int) -> dict:
     goal_entries: list[dict[str, Any]] = [
         {"goal": g, "per_payout": goal_payout_amount(g, payout_period_count)} for g in goals
     ]
+    # Computed once for the whole request (O(n) in the number of payout
+    # periods) rather than once per period -- see `_all_channel_balances`.
+    carry_in_by_period, balances_by_period = _all_channel_balances(db, user_id)
     payout_data = []
     for period in payout_periods:
         expenses = [e for e in all_expenses if e.payout_period_id == period.id]
         transfers = _order_transfers(channels, list_transfers(db, period.id, user_id))
         goal_contributions = list_goal_contributions(db, period.id, user_id)
-        balances = channel_balances(db, period.id, user_id)
+        balances = balances_by_period.get(period.id, [])
+        # Matches `cashflow_warnings`'s own (non-summing, last-write-wins)
+        # dict construction so the embedded "warnings" below stay identical
+        # to a direct `cashflow_warnings(db, period.id, user_id)` call.
+        contributed_for_warnings = {c.goal_id: float(c.amount) for c in goal_contributions}
         contributed_by_goal: dict[int, float] = {}
         for gc in goal_contributions:
             contributed_by_goal[gc.goal_id] = contributed_by_goal.get(gc.goal_id, 0.0) + float(
@@ -1377,8 +1427,10 @@ def cashflow_page_data(db: Session, user_id: int) -> dict:
                 "balances": balances,
                 "balance_by_channel": {c.id: net for c, net in balances},
                 "contributed_by_goal": contributed_by_goal,
-                "carry_in": _carry_in_for_period(db, period.id, user_id),
-                "warnings": cashflow_warnings(db, period.id, user_id),
+                "carry_in": carry_in_by_period.get(period.id, {}),
+                "warnings": _cashflow_warnings_from_balances(
+                    balances, goals, payout_period_count, contributed_for_warnings
+                ),
                 "expenses_by_channel": expenses_by_channel,
                 "position_by_channel": position_by_channel,
                 "position_by_goal": position_by_goal,

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,6 +1,11 @@
 import re
+import time
 
+import pytest
 from fastapi.testclient import TestClient
+
+from app import crud, schemas
+from tests.conftest import TEST_USER_ID, TestingSessionLocal
 
 
 def _create_channel(client: TestClient, name: str) -> str:
@@ -130,3 +135,155 @@ def test_cashflow_canvas_shows_channel_nodes_with_balances(
     assert f'data-node-id="channel-{b}"' in response.text
     assert "1,000.00" in response.text
     assert "-₱500.00" in response.text
+
+
+def test_channel_balances_carry_forward_across_many_periods() -> None:
+    """Regression test for #67 (exponential-time recursion in the balance
+    calculation): builds 9 payout periods where each period's balance
+    depends on carry-in from the one before it, then checks every period's
+    `channel_balances()` and `cashflow_page_data()` output against an
+    independent, hand-written step-by-step simulation. Also cross-checks
+    `cashflow_page_data()`'s per-period `carry_in`/`balance_by_channel`
+    against the single-period `channel_balances()` entry point, since the
+    fix must keep both call paths in agreement."""
+    db = TestingSessionLocal()
+    try:
+        channel_a = crud.create_channel(db, schemas.ChannelCreate(name="Channel A"), TEST_USER_ID)
+        channel_b = crud.create_channel(db, schemas.ChannelCreate(name="Channel B"), TEST_USER_ID)
+
+        period_count = 9
+        periods = []
+        incomes = []
+        transfer_amounts = []
+        expense_a_amounts = []
+        expense_b_amount = 25.0  # constant, alongside the varying amounts below
+
+        for i in range(1, period_count + 1):
+            income = 1000.0 + i * 10
+            period = crud.create_payout_period(
+                db,
+                schemas.PayoutPeriodCreate(
+                    label=f"Period {i}",
+                    income_amount=income,
+                    receiving_channel_id=channel_a.id,
+                ),
+                TEST_USER_ID,
+            )
+            periods.append(period)
+            incomes.append(income)
+
+            transfer_amount = 150.0 + i * 5
+            transfer_amounts.append(transfer_amount)
+            crud.create_transfer(
+                db,
+                schemas.TransferCreate(
+                    payout_period_id=period.id,
+                    from_channel_id=channel_a.id,
+                    to_channel_id=channel_b.id,
+                    amount=transfer_amount,
+                ),
+                TEST_USER_ID,
+            )
+
+            expense_a = 40.0 + i
+            expense_a_amounts.append(expense_a)
+            crud.create_expense(
+                db,
+                schemas.ExpenseCreate(
+                    name=f"A bill {i}",
+                    amount=expense_a,
+                    payout_period_id=period.id,
+                    channel_id=channel_a.id,
+                ),
+                TEST_USER_ID,
+            )
+            crud.create_expense(
+                db,
+                schemas.ExpenseCreate(
+                    name=f"B bill {i}",
+                    amount=expense_b_amount,
+                    payout_period_id=period.id,
+                    channel_id=channel_b.id,
+                ),
+                TEST_USER_ID,
+            )
+
+        # Independent step-by-step simulation -- not calling any of crud's
+        # carry-in logic -- that the balances below are checked against.
+        carry_a = 0.0
+        carry_b = 0.0
+        expected: list[tuple[float, float]] = []
+        for i in range(period_count):
+            net_a = carry_a + incomes[i] - transfer_amounts[i] - expense_a_amounts[i]
+            net_b = carry_b + transfer_amounts[i] - expense_b_amount
+            expected.append((net_a, net_b))
+            carry_a, carry_b = net_a, net_b
+
+        for i, period in enumerate(periods):
+            balances = {c.id: net for c, net in crud.channel_balances(db, period.id, TEST_USER_ID)}
+            assert balances[channel_a.id] == pytest.approx(expected[i][0])
+            assert balances[channel_b.id] == pytest.approx(expected[i][1])
+
+        # cashflow_page_data must produce identical balances/carry-in for
+        # every period as the single-period channel_balances() calls above --
+        # both code paths now share the same O(n) internal computation.
+        page_data = crud.cashflow_page_data(db, TEST_USER_ID)
+        assert len(page_data["payout_data"]) == period_count
+        for i, entry in enumerate(page_data["payout_data"]):
+            balance_by_channel = entry["balance_by_channel"]
+            assert balance_by_channel[channel_a.id] == pytest.approx(expected[i][0])
+            assert balance_by_channel[channel_b.id] == pytest.approx(expected[i][1])
+            if i == 0:
+                assert entry["carry_in"] == {}
+            else:
+                assert entry["carry_in"][channel_a.id] == pytest.approx(expected[i - 1][0])
+                assert entry["carry_in"][channel_b.id] == pytest.approx(expected[i - 1][1])
+    finally:
+        db.close()
+
+
+def test_cashflow_page_data_completes_quickly_with_many_periods() -> None:
+    """Perf-sanity regression test for #67: before the fix, computing N
+    periods' balances was exponential (each period re-deriving every prior
+    period from scratch), so ~20 periods would hang the request. Asserts the
+    whole page's data assembly -- which used to redo this exponential work
+    three times per period -- stays comfortably fast."""
+    db = TestingSessionLocal()
+    try:
+        channel_a = crud.create_channel(db, schemas.ChannelCreate(name="Channel A"), TEST_USER_ID)
+        channel_b = crud.create_channel(db, schemas.ChannelCreate(name="Channel B"), TEST_USER_ID)
+
+        for i in range(1, 21):
+            period = crud.create_payout_period(
+                db,
+                schemas.PayoutPeriodCreate(
+                    label=f"Period {i}", income_amount=1000, receiving_channel_id=channel_a.id
+                ),
+                TEST_USER_ID,
+            )
+            crud.create_transfer(
+                db,
+                schemas.TransferCreate(
+                    payout_period_id=period.id,
+                    from_channel_id=channel_a.id,
+                    to_channel_id=channel_b.id,
+                    amount=200,
+                ),
+                TEST_USER_ID,
+            )
+            crud.create_expense(
+                db,
+                schemas.ExpenseCreate(
+                    name=f"bill {i}", amount=30, payout_period_id=period.id, channel_id=channel_b.id
+                ),
+                TEST_USER_ID,
+            )
+
+        start = time.perf_counter()
+        crud.cashflow_page_data(db, TEST_USER_ID)
+        elapsed = time.perf_counter() - start
+        assert (
+            elapsed < 2.0
+        ), f"cashflow_page_data took {elapsed:.2f}s for 20 periods -- likely exponential again"
+    finally:
+        db.close()


### PR DESCRIPTION
Closes #67.

## Before

`_carry_in_for_period()` looped over every prior payout period and called `channel_balances()` for each -- but `channel_balances()` itself called `_carry_in_for_period()` internally. Computing period k's balance triggered k calls to compute period k-1, each triggering k-1 calls to compute period k-2, and so on: T(k) = T(0)+T(1)+...+T(k-1), which is exponential (~2^(k-2)). `cashflow_page_data()` made it worse by calling `channel_balances()`, `_carry_in_for_period()`, and `cashflow_warnings()` (which itself calls `channel_balances()`) separately for the *same* period in its per-period loop -- three independent exponential computations per period. `overview_warnings()` had the same problem, calling `cashflow_warnings()` once per period.

## After

Added `_all_channel_balances(db, user_id)` (`app/crud.py`), which computes every payout period's carry-in and channel balances in a single O(n) pass over `list_payout_periods()` in `display_order`, feeding each period's already-computed ending balances forward as the next period's carry-in directly -- no re-derivation of prior periods.

- `_carry_in_for_period()` and `channel_balances()` (public signature/return-shape unchanged) now delegate to `_all_channel_balances()` as single-period convenience wrappers -- safe for any external caller invoking them once, but each call is still O(n), so callers that need multiple periods must not call these in a loop.
- `cashflow_page_data()` now calls `_all_channel_balances()` once up front and indexes into the result for every period's `balances`/`balance_by_channel`/`carry_in`, instead of three separate per-period recomputations. The embedded per-period `warnings` are computed with a new `_cashflow_warnings_from_balances()` helper, factored out of `cashflow_warnings()`, fed the already-fetched `balances`/`goal_contributions` for that period rather than re-querying/re-deriving them.
- `overview_warnings()` now also calls `_all_channel_balances()` once and reuses `_cashflow_warnings_from_balances()` per period, instead of calling `cashflow_warnings()` (and therefore `channel_balances()`) once per period.
- `preview_canvas()` is unchanged in structure (already single-period, calls `_carry_in_for_period()` once) -- it benefits automatically since that call is no longer exponential.
- `expenses_page_data()` doesn't touch balances at all, so it wasn't affected.

Behavior (return values) is unchanged everywhere -- this is a pure algorithmic refactor.

## Verification

- Added `test_channel_balances_carry_forward_across_many_periods` (`tests/test_transfers.py`): builds 9 payout periods with per-period income/transfers/expenses on 2 channels, computes expected balances via an independent step-by-step simulation written in the test (not calling any crud carry-in logic), and asserts `channel_balances()` matches for every period, and that `cashflow_page_data()`'s per-period `balance_by_channel`/`carry_in` agree with those same values -- this is what gives confidence the refactor is behavior-preserving, not just "tests pass": the two entry points (single-period `channel_balances()` and the whole-page `cashflow_page_data()`) are checked against the same externally-derived expected numbers.
- Added `test_cashflow_page_data_completes_quickly_with_many_periods`: 20 periods, asserts `cashflow_page_data()` completes in well under 2s. I verified this test actually has teeth by temporarily stashing the `app/crud.py` fix and running just this test against the old code -- it hung for over a minute (timed out) with only 20 periods, confirming the exponential blowup was real and this regression test would have caught it.
- Reran the full existing suite (`poetry run pytest`) -- all pre-existing tests pass unchanged (one pre-existing, unrelated failure: `test_update_profile_persists_all_fields`, fails identically on unmodified `dev` -- a Windows `America/New_York` tzdata gap, unrelated to this change).
- `ruff check`, `ruff format --check`, `mypy app tests`, `djlint --check` all pass.