### PR TITLE
(fix) block deleting channels/payout periods still referenced elsewhere

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -63,6 +63,10 @@ class ChannelInUseError(Exception):
     """Raised when deleting a channel that is still referenced elsewhere."""
 
 
+class PayoutPeriodInUseError(Exception):
+    """Raised when deleting a payout period that is still referenced elsewhere."""
+
+
 class OwnershipError(Exception):
     """Raised when a referenced row doesn't belong to the acting user."""
 
@@ -398,12 +402,15 @@ def delete_channel(db: Session, channel_id: int, user_id: int) -> None:
         or db.query(models.GoalContribution)
         .filter_by(channel_id=channel_id, user_id=user_id)
         .first()
+        or db.query(models.Goal).filter_by(channel_id=channel_id, user_id=user_id).first()
+        or db.query(models.CreditLine).filter_by(channel_id=channel_id, user_id=user_id).first()
+        or db.query(models.Asset).filter_by(channel_id=channel_id, user_id=user_id).first()
     )
     if in_use is not None:
         raise ChannelInUseError(
             "This channel is still used by a payout period, expense, transfer, "
-            "or goal contribution, and can't be deleted until those are removed "
-            "or reassigned."
+            "goal contribution, goal, credit line, or asset, and can't be "
+            "deleted until those are removed or reassigned."
         )
 
     db.query(models.ChannelPlacement).filter_by(channel_id=channel_id, user_id=user_id).delete()
@@ -460,9 +467,35 @@ def update_payout_period(
 
 def delete_payout_period(db: Session, payout_period_id: int, user_id: int) -> None:
     period = _owned(db, models.PayoutPeriod, payout_period_id, user_id)
-    if period is not None:
-        db.delete(period)
-        db.commit()
+    if period is None:
+        return
+
+    in_use = (
+        db.query(models.Expense)
+        .filter_by(payout_period_id=payout_period_id, user_id=user_id)
+        .first()
+        or db.query(models.Transfer)
+        .filter_by(payout_period_id=payout_period_id, user_id=user_id)
+        .first()
+        or db.query(models.GoalContribution)
+        .filter_by(payout_period_id=payout_period_id, user_id=user_id)
+        .first()
+        or db.query(models.ChannelPlacement)
+        .filter_by(payout_period_id=payout_period_id, user_id=user_id)
+        .first()
+        or db.query(models.GoalPlacement)
+        .filter_by(payout_period_id=payout_period_id, user_id=user_id)
+        .first()
+    )
+    if in_use is not None:
+        raise PayoutPeriodInUseError(
+            "This payout period is still used by an expense, transfer, goal "
+            "contribution, or canvas placement, and can't be deleted until "
+            "those are removed or reassigned."
+        )
+
+    db.delete(period)
+    db.commit()
 
 
 # --- Expenses -----------------------------------------------------------------

--- a/app/routers/payout_periods.py
+++ b/app/routers/payout_periods.py
@@ -75,5 +75,8 @@ def delete_payout_period(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> HTMLResponse:
-    crud.delete_payout_period(db, payout_period_id, current_user.id)
+    try:
+        crud.delete_payout_period(db, payout_period_id, current_user.id)
+    except crud.PayoutPeriodInUseError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return _render_page(request, db, current_user.id)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -64,6 +64,41 @@ def test_delete_channel_in_use_by_payout_period_is_rejected(client: TestClient) 
     assert "still used" in response.json()["detail"]
 
 
+def test_delete_channel_in_use_by_goal_is_rejected(client: TestClient) -> None:
+    channel_id = _create_channel(client, "GCash")
+    client.post(
+        "/goals",
+        data={"name": "CAR DP", "target": "100000", "months": "6", "channel_id": channel_id},
+    )
+
+    response = client.delete(f"/channels/{channel_id}")
+    assert response.status_code == 409
+    assert "still used" in response.json()["detail"]
+
+
+def test_delete_channel_in_use_by_credit_line_is_rejected(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI Credit")
+    client.post(
+        "/credit",
+        data={"name": "BPI Card", "limit": "50000", "used": "0", "channel_id": channel_id},
+    )
+
+    response = client.delete(f"/channels/{channel_id}")
+    assert response.status_code == 409
+    assert "still used" in response.json()["detail"]
+
+
+def test_delete_channel_in_use_by_asset_is_rejected(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Time Deposit")
+    client.post(
+        "/assets", data={"name": "Emergency Fund", "amount": "10000", "channel_id": channel_id}
+    )
+
+    response = client.delete(f"/channels/{channel_id}")
+    assert response.status_code == 409
+    assert "still used" in response.json()["detail"]
+
+
 def _create_payout_period(client: TestClient, channel_id: str) -> str:
     response = client.post(
         "/payout-periods",

--- a/tests/test_payout_periods.py
+++ b/tests/test_payout_periods.py
@@ -46,3 +46,42 @@ def test_update_payout_period_income(client: TestClient) -> None:
     )
     assert response.status_code == 200
     assert "2000" in response.text
+
+
+def test_delete_empty_payout_period_succeeds(client: TestClient) -> None:
+    create = client.post(
+        "/payout-periods",
+        data={"label": "Empty Period", "income_amount": "0", "receiving_channel_id": ""},
+    )
+    match = re.search(r"/payout-periods/(\d+)", create.text)
+    assert match is not None
+    period_id = match.group(1)
+
+    response = client.delete(f"/payout-periods/{period_id}")
+    assert response.status_code == 200
+    assert "Empty Period" not in response.text
+
+
+def test_delete_payout_period_in_use_by_expense_is_rejected(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    create = client.post(
+        "/payout-periods",
+        data={"label": "15th", "income_amount": "1000", "receiving_channel_id": channel_id},
+    )
+    match = re.search(r"/payout-periods/(\d+)", create.text)
+    assert match is not None
+    period_id = match.group(1)
+
+    client.post(
+        "/expenses",
+        data={
+            "name": "Rent",
+            "amount": "5000",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+
+    response = client.delete(f"/payout-periods/{period_id}")
+    assert response.status_code == 409
+    assert "still used" in response.json()["detail"]


### PR DESCRIPTION
Closes #68

## Summary

Both gaps from the issue shared a root cause: no in-use precheck before deleting a row other tables FK to, so Postgres's default RESTRICT turned the delete into a raw `IntegrityError`/`ForeignKeyViolation` 500 instead of a friendly error.

### 1. `delete_channel` (`app/crud.py`)
Extended the existing in-use query to also check `Goal.channel_id`, `CreditLine.channel_id`, and `Asset.channel_id` (previously only `PayoutPeriod.receiving_channel_id`, `Expense.channel_id`, `Transfer.from/to_channel_id`, `GoalContribution.channel_id` were checked). Updated `ChannelInUseError`'s message to mention the new cases.

### 2. `delete_payout_period` (`app/crud.py`)
Previously did an ownership lookup then deleted with zero precheck. Added an in-use precheck across the 5 tables that FK to `payout_periods.id`: `Expense`, `Transfer`, `GoalContribution`, `ChannelPlacement`, `GoalPlacement`. Raises a new `PayoutPeriodInUseError` (mirrors `ChannelInUseError`'s shape/message) if any exist.

**Precheck vs. cascade**: chose a precheck (matching `delete_channel`'s pattern), not child-cleanup (matching `delete_goal`'s pattern). `Expense`, `Transfer`, and `GoalContribution` represent real financial records the user explicitly entered for that period — silently cascading them away on a payout-period delete risks quietly destroying data the user didn't ask to remove. `ChannelPlacement`/`GoalPlacement` are just canvas layout state, but they're included in the same precheck for simplicity and because a period with those but nothing else is an edge case not worth a separate code path.

`app/routers/payout_periods.py`'s `DELETE /payout-periods/{id}` now catches `PayoutPeriodInUseError` the same way `channels.py` catches `ChannelInUseError` -> HTTP 409 with the error message as `detail`.

## Tests
- `tests/test_payout_periods.py`: empty-period delete succeeds (200, period gone from re-rendered page); a period referenced by an expense is blocked with 409 + "still used" in the detail.
- `tests/test_channels.py`: three new cases -- channel referenced by a Goal, a CreditLine, and an Asset are each blocked with 409.

## Validation
```
poetry run ruff check .            # pass
poetry run ruff format .           # pass (1 file auto-reformatted, re-verified clean)
poetry run mypy app tests          # pass, no issues
poetry run djlint app/templates --profile jinja --check   # pass, 0 files would update
poetry run pytest                  # 162 passed, 1 failed (test_update_profile_persists_all_fields -- known unrelated local zoneinfo/tzdata gap per task instructions)
```