### PR TITLE
(fix) add server-side validation for amounts and name fields

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -70,8 +70,14 @@ def schema_validation_error_handler(request: Request, exc: ValidationError) -> R
     # so FastAPI's own automatic RequestValidationError -> 422 handling never
     # kicks in for a gt=0/min_length violation raised inside a route body --
     # without this handler it would surface as an unhandled 500 instead.
-    # Mirrors FastAPI's default RequestValidationError response shape.
-    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": exc.errors()}))
+    #
+    # `detail` must be a plain string, not FastAPI's default list-of-dicts
+    # shape: base.html's global `htmx:responseError` listener does
+    # `alertMessage.textContent = data.detail` for every error path in this
+    # app (see OwnershipError -> 404, ChannelInUseError -> 409, both plain
+    # strings) -- assigning an array there would render as "[object Object]".
+    message = "; ".join(f"{err['loc'][-1]}: {err['msg']}" for err in exc.errors())
+    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": message}))
 
 
 app.include_router(auth.router)

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,10 @@
 import os
 
 from fastapi import Depends, FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
+from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -58,6 +60,18 @@ def not_authenticated_handler(request: Request, exc: NotAuthenticated) -> Respon
     if request.headers.get("HX-Request") == "true":
         return Response(status_code=200, headers={"HX-Redirect": "/login"})
     return RedirectResponse(url="/login", status_code=303)
+
+
+@app.exception_handler(ValidationError)
+def schema_validation_error_handler(request: Request, exc: ValidationError) -> Response:
+    # Routers build app/schemas.py models by hand from individually-parsed
+    # Form(...) fields (see CLAUDE.md's "Optional FK form fields" note) rather
+    # than declaring the schema itself as a FastAPI request-body dependency,
+    # so FastAPI's own automatic RequestValidationError -> 422 handling never
+    # kicks in for a gt=0/min_length violation raised inside a route body --
+    # without this handler it would surface as an unhandled 500 instead.
+    # Mirrors FastAPI's default RequestValidationError response shape.
+    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": exc.errors()}))
 
 
 app.include_router(auth.router)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,33 +1,43 @@
-from pydantic import BaseModel, Field
+from typing import Annotated
+
+from pydantic import BaseModel, Field, StringConstraints
+
+# A name/label field that must be non-empty once surrounding whitespace is
+# stripped -- StringConstraints(strip_whitespace=True) strips *before* the
+# min_length check runs, so a whitespace-only value (e.g. "   ") is rejected
+# rather than passing as a "non-empty" 3-character string. See issue #69.
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class ChannelCreate(BaseModel):
-    name: str
+    name: NonEmptyStr
     color: str = "#8a8a8a"
     channel_type: str | None = None
     badge_label: str | None = None
 
 
 class ChannelUpdate(BaseModel):
-    name: str
+    name: NonEmptyStr
     color: str
     channel_type: str | None = None
 
 
 class PayoutPeriodCreate(BaseModel):
-    label: str
-    income_amount: float = 0
+    label: NonEmptyStr
+    # 0 is legitimate here -- a brand-new payout period with no income
+    # configured yet.
+    income_amount: float = Field(default=0, ge=0)
     receiving_channel_id: int | None = None
 
 
 class PayoutPeriodUpdate(BaseModel):
-    income_amount: float
+    income_amount: float = Field(ge=0)
     receiving_channel_id: int | None = None
 
 
 class ExpenseCreate(BaseModel):
-    name: str
-    amount: float
+    name: NonEmptyStr
+    amount: float = Field(gt=0)
     payout_period_id: int
     channel_id: int
     due_day: int | None = Field(default=None, ge=1, le=31)
@@ -37,37 +47,37 @@ class TransferCreate(BaseModel):
     payout_period_id: int
     from_channel_id: int
     to_channel_id: int
-    amount: float
+    amount: float = Field(gt=0)
 
 
 class TransferUpdate(BaseModel):
-    amount: float
+    amount: float = Field(gt=0)
 
 
 class AssetCreate(BaseModel):
-    name: str
-    amount: float
+    name: NonEmptyStr
+    amount: float = Field(gt=0)
     channel_id: int | None = None
 
 
 class AssetUpdate(BaseModel):
-    name: str
-    amount: float
+    name: NonEmptyStr
+    amount: float = Field(gt=0)
     channel_id: int | None = None
 
 
 class GoalCreate(BaseModel):
-    name: str
-    target: float
-    months: int = 1
+    name: NonEmptyStr
+    target: float = Field(gt=0)
+    months: int = Field(default=1, gt=0)
     channel_id: int | None = None
     round_up_to_hundred: bool = False
 
 
 class GoalUpdate(BaseModel):
-    name: str
-    target: float
-    months: int
+    name: NonEmptyStr
+    target: float = Field(gt=0)
+    months: int = Field(gt=0)
     channel_id: int | None = None
     round_up_to_hundred: bool = False
 
@@ -76,11 +86,11 @@ class GoalContributionCreate(BaseModel):
     goal_id: int
     channel_id: int
     payout_period_id: int
-    amount: float
+    amount: float = Field(gt=0)
 
 
 class GoalContributionUpdate(BaseModel):
-    amount: float
+    amount: float = Field(gt=0)
 
 
 class PlacementUpdate(BaseModel):
@@ -128,14 +138,16 @@ class CanvasPreviewOut(BaseModel):
 
 
 class CreditLineCreate(BaseModel):
-    name: str
-    limit: float
-    used: float = 0
+    name: NonEmptyStr
+    limit: float = Field(gt=0)
+    # 0 is legitimate here -- a brand-new credit line with nothing charged
+    # to it yet.
+    used: float = Field(default=0, ge=0)
     channel_id: int | None = None
 
 
 class CreditLineUpdate(BaseModel):
-    name: str
-    limit: float
-    used: float
+    name: NonEmptyStr
+    limit: float = Field(gt=0)
+    used: float = Field(ge=0)
     channel_id: int | None = None

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -23,6 +23,17 @@ def test_update_asset_renames_and_changes_amount(client: TestClient) -> None:
     assert "Maya TD" not in response.text
 
 
+def test_create_asset_rejects_zero_or_negative_amount(client: TestClient) -> None:
+    for amount in ("0", "-11210.80"):
+        response = client.post("/assets", data={"name": "BPI IMI", "amount": amount})
+        assert response.status_code == 422
+
+
+def test_create_asset_rejects_whitespace_only_name(client: TestClient) -> None:
+    response = client.post("/assets", data={"name": "   ", "amount": "1000"})
+    assert response.status_code == 422
+
+
 def test_delete_asset(client: TestClient) -> None:
     create = client.post("/assets", data={"name": "Temp Asset", "amount": "500"})
     match = re.search(r'/assets/(\d+)"', create.text)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -16,6 +16,21 @@ def test_create_channel_appears_on_page(client: TestClient) -> None:
     assert "BPI" in response.text
 
 
+def test_create_channel_rejects_whitespace_only_name(client: TestClient) -> None:
+    response = client.post("/channels", data={"name": "   ", "color": "#8a8a8a"})
+    assert response.status_code == 422
+
+
+def test_update_channel_rejects_whitespace_only_name(client: TestClient) -> None:
+    create = client.post("/channels", data={"name": "Maya", "color": "#0FA968"})
+    match = re.search(r'/channels/(\d+)"', create.text)
+    assert match is not None
+    channel_id = match.group(1)
+
+    response = client.patch(f"/channels/{channel_id}", data={"name": "   ", "color": "#0FA968"})
+    assert response.status_code == 422
+
+
 def test_update_channel_renames_it(client: TestClient) -> None:
     create = client.post("/channels", data={"name": "Maya", "color": "#0FA968"})
     assert "Maya" in create.text

--- a/tests/test_credit.py
+++ b/tests/test_credit.py
@@ -32,6 +32,22 @@ def test_update_credit_line_renames_and_changes_amounts(client: TestClient) -> N
     assert "Old Card" not in response.text
 
 
+def test_create_credit_line_rejects_zero_or_negative_limit(client: TestClient) -> None:
+    for limit in ("0", "-1000"):
+        response = client.post("/credit", data={"name": "Maya Black", "limit": limit, "used": "0"})
+        assert response.status_code == 422
+
+
+def test_create_credit_line_rejects_negative_used(client: TestClient) -> None:
+    response = client.post("/credit", data={"name": "Maya Black", "limit": "1000", "used": "-1"})
+    assert response.status_code == 422
+
+
+def test_create_credit_line_rejects_whitespace_only_name(client: TestClient) -> None:
+    response = client.post("/credit", data={"name": "   ", "limit": "1000", "used": "0"})
+    assert response.status_code == 422
+
+
 def test_delete_credit_line(client: TestClient) -> None:
     create = client.post("/credit", data={"name": "Temp Card", "limit": "1000", "used": "0"})
     match = re.search(r'/credit/(\d+)"', create.text)

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -100,6 +100,29 @@ def test_create_expense_rejects_zero_or_negative_amount(client: TestClient) -> N
         assert response.status_code == 422
 
 
+def test_validation_error_detail_is_a_plain_string_not_a_list(client: TestClient) -> None:
+    # base.html's global htmx:responseError listener does
+    # `alertMessage.textContent = data.detail` for every error path in this
+    # app -- if `detail` were pydantic's default list-of-dicts shape instead
+    # of a plain string, the user-facing alert would render "[object Object]".
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", channel_id)
+
+    response = client.post(
+        "/expenses",
+        data={
+            "name": "Groceries",
+            "amount": "-50",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, str)
+    assert "amount" in detail
+
+
 def test_create_expense_rejects_whitespace_only_name(client: TestClient) -> None:
     channel_id = _create_channel(client, "BPI")
     period_id = _create_payout_period(client, "15th", channel_id)

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -83,6 +83,39 @@ def test_create_expense_without_due_day_leaves_it_blank(client: TestClient) -> N
     assert "Groceries" in create.text
 
 
+def test_create_expense_rejects_zero_or_negative_amount(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", channel_id)
+
+    for amount in ("0", "-50"):
+        response = client.post(
+            "/expenses",
+            data={
+                "name": "Groceries",
+                "amount": amount,
+                "payout_period_id": period_id,
+                "channel_id": channel_id,
+            },
+        )
+        assert response.status_code == 422
+
+
+def test_create_expense_rejects_whitespace_only_name(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", channel_id)
+
+    response = client.post(
+        "/expenses",
+        data={
+            "name": "   ",
+            "amount": "150.75",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+    assert response.status_code == 422
+
+
 def test_expenses_filter_by_name(client: TestClient) -> None:
     channel_id = _create_channel(client, "BPI")
     period_id = _create_payout_period(client, "15th", channel_id)

--- a/tests/test_goal_contributions.py
+++ b/tests/test_goal_contributions.py
@@ -68,6 +68,48 @@ def test_create_goal_contribution_updates_goal_allocated(client: TestClient) -> 
     assert "30%" in goals_page.text
 
 
+def test_create_goal_contribution_rejects_zero_or_negative_amount(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Savings")
+    period_id = _create_payout_period(client, "15th")
+    goal_id = _create_goal(client, "Emergency Fund", "1000")
+
+    for amount in ("0", "-300"):
+        response = client.post(
+            "/goal-contributions",
+            data={
+                "goal_id": goal_id,
+                "channel_id": channel_id,
+                "payout_period_id": period_id,
+                "amount": amount,
+            },
+        )
+        assert response.status_code == 422
+
+
+def test_update_goal_contribution_rejects_zero_or_negative_amount(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Savings")
+    period_id = _create_payout_period(client, "15th")
+    goal_id = _create_goal(client, "Emergency Fund", "1000")
+    _place_channel(client, period_id, channel_id)
+    _place_goal(client, period_id, goal_id)
+
+    create = client.post(
+        "/goal-contributions",
+        data={
+            "goal_id": goal_id,
+            "channel_id": channel_id,
+            "payout_period_id": period_id,
+            "amount": "300",
+        },
+    )
+    match = re.search(r'data-edge-id="goal-contribution-(\d+)"', create.text)
+    assert match is not None
+    contribution_id = match.group(1)
+
+    response = client.patch(f"/goal-contributions/{contribution_id}", data={"amount": "0"})
+    assert response.status_code == 422
+
+
 def test_update_goal_contribution_recomputes_allocated(client: TestClient) -> None:
     channel_id = _create_channel(client, "Savings")
     period_id = _create_payout_period(client, "15th")

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -55,6 +55,37 @@ def test_update_goal_renames_and_changes_amounts(client: TestClient) -> None:
     assert "Old Name" not in response.text
 
 
+def test_create_goal_rejects_zero_or_negative_target(client: TestClient) -> None:
+    for target in ("0", "-1000"):
+        response = client.post("/goals", data={"name": "CAR DP", "target": target, "months": "6"})
+        assert response.status_code == 422
+
+
+def test_create_goal_rejects_zero_or_negative_months(client: TestClient) -> None:
+    for months in ("0", "-1"):
+        response = client.post(
+            "/goals", data={"name": "CAR DP", "target": "100000", "months": months}
+        )
+        assert response.status_code == 422
+
+
+def test_create_goal_rejects_whitespace_only_name(client: TestClient) -> None:
+    response = client.post("/goals", data={"name": "   ", "target": "1000", "months": "1"})
+    assert response.status_code == 422
+
+
+def test_update_goal_rejects_zero_or_negative_target(client: TestClient) -> None:
+    create = client.post("/goals", data={"name": "Old Name", "target": "1000", "months": "1"})
+    match = re.search(r'/goals/(\d+)"', create.text)
+    assert match is not None
+    goal_id = match.group(1)
+
+    response = client.patch(
+        f"/goals/{goal_id}", data={"name": "Old Name", "target": "-2000", "months": "4"}
+    )
+    assert response.status_code == 422
+
+
 def test_delete_goal(client: TestClient) -> None:
     create = client.post("/goals", data={"name": "Temp Goal", "target": "1000", "months": "1"})
     match = re.search(r'/goals/(\d+)"', create.text)

--- a/tests/test_payout_periods.py
+++ b/tests/test_payout_periods.py
@@ -30,6 +30,39 @@ def test_create_payout_period_with_no_channel(client: TestClient) -> None:
     assert "30th" in response.text
 
 
+def test_create_payout_period_rejects_whitespace_only_label(client: TestClient) -> None:
+    response = client.post(
+        "/payout-periods",
+        data={"label": "   ", "income_amount": "1000", "receiving_channel_id": ""},
+    )
+    assert response.status_code == 422
+
+
+def test_create_payout_period_rejects_negative_income(client: TestClient) -> None:
+    response = client.post(
+        "/payout-periods",
+        data={"label": "15th", "income_amount": "-100", "receiving_channel_id": ""},
+    )
+    assert response.status_code == 422
+
+
+def test_update_payout_period_rejects_negative_income(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    create = client.post(
+        "/payout-periods",
+        data={"label": "15th", "income_amount": "1000", "receiving_channel_id": channel_id},
+    )
+    match = re.search(r"/payout-periods/(\d+)", create.text)
+    assert match is not None
+    period_id = match.group(1)
+
+    response = client.patch(
+        f"/payout-periods/{period_id}",
+        data={"income_amount": "-2000", "receiving_channel_id": channel_id},
+    )
+    assert response.status_code == 422
+
+
 def test_update_payout_period_income(client: TestClient) -> None:
     channel_id = _create_channel(client, "BPI")
     create = client.post(

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -66,6 +66,50 @@ def test_create_update_delete_transfer(client: TestClient) -> None:
     assert deleted.status_code == 200
 
 
+def test_create_transfer_rejects_zero_or_negative_amount(client: TestClient) -> None:
+    a = _create_channel(client, "Channel A")
+    b = _create_channel(client, "Channel B")
+    period_id = _create_payout_period(client, "15th", "1000", a)
+    _place_channel(client, period_id, a)
+    _place_channel(client, period_id, b)
+
+    for amount in ("0", "-300"):
+        response = client.post(
+            "/transfers",
+            data={
+                "payout_period_id": period_id,
+                "from_channel_id": a,
+                "to_channel_id": b,
+                "amount": amount,
+            },
+        )
+        assert response.status_code == 422
+
+
+def test_update_transfer_rejects_zero_or_negative_amount(client: TestClient) -> None:
+    a = _create_channel(client, "Channel A")
+    b = _create_channel(client, "Channel B")
+    period_id = _create_payout_period(client, "15th", "1000", a)
+    _place_channel(client, period_id, a)
+    _place_channel(client, period_id, b)
+
+    create = client.post(
+        "/transfers",
+        data={
+            "payout_period_id": period_id,
+            "from_channel_id": a,
+            "to_channel_id": b,
+            "amount": "300",
+        },
+    )
+    match = re.search(r'data-edge-id="transfer-(\d+)"', create.text)
+    assert match is not None
+    transfer_id = match.group(1)
+
+    response = client.patch(f"/transfers/{transfer_id}", data={"amount": "-400"})
+    assert response.status_code == 422
+
+
 def test_channel_balances_reflect_income_transfers_and_expenses(client: TestClient) -> None:
     """Worked example: A receives 1000 income, sends 300 to B.
     A also has a 100 expense, B has a 50 expense.


### PR DESCRIPTION
Closes #69.

## Summary

`app/schemas.py` had no numeric or non-empty constraints on any Create/Update model, so a negative or zero amount would silently corrupt `channel_balances()`, goal math, or credit utilization instead of failing loudly. This adds constraints per field below, plus a global exception handler so a constraint violation actually surfaces as a 422 rather than an unhandled 500.

## Fields constrained, and why

**`gt=0`** (must be strictly positive — a $0 entry of these kinds doesn't make sense):
- `ExpenseCreate.amount`
- `TransferCreate.amount`, `TransferUpdate.amount`
- `AssetCreate.amount`, `AssetUpdate.amount`
- `GoalCreate.target`, `GoalUpdate.target`
- `GoalCreate.months`, `GoalUpdate.months` — 0 or negative months is nonsensical for target ÷ months
- `GoalContributionCreate.amount`, `GoalContributionUpdate.amount`
- `CreditLineCreate.limit`, `CreditLineUpdate.limit`

**`ge=0`** (zero is legitimately meaningful):
- `PayoutPeriodCreate.income_amount`, `PayoutPeriodUpdate.income_amount` — a brand-new payout period with no income configured yet. Several existing tests already create periods with `income_amount=0` expecting success.
- `CreditLineCreate.used`, `CreditLineUpdate.used` — a brand-new credit line with nothing charged yet. Existing tests already create credit lines with `used=0` expecting success.

`Goal.allocated` from the issue's suggested list doesn't actually exist as a schema field — it's a `models.Goal` column recomputed internally by `crud._recompute_goal_allocated`, never accepted as Create/Update input, so no constraint was needed there.

**Non-empty after `.strip()`** (via a shared `NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]`, which strips before the length check so whitespace-only values are rejected, not just truly-empty ones):
- `Channel.name` (Create/Update)
- `Expense.name` (Create only — there's no `ExpenseUpdate` schema in this codebase)
- `PayoutPeriod.label` (Create only — `PayoutPeriodUpdate` doesn't accept `label`)
- `Goal.name` (Create/Update)
- `CreditLine.name` (Create/Update)
- `Asset.name` (Create/Update)

Left untouched (out of scope per the issue): `Channel.color`/`channel_type`/`badge_label`, boolean flags, and every FK id field, plus the `Canvas*In` schemas (not named in the issue's fix direction).

## Why a new exception handler was needed

Every mutating router (`expenses.py`, `transfers.py`, `goals.py`, `credit.py`, `assets.py`, `goal_contributions.py`, `channels.py`, `payout_periods.py`) constructs the `schemas.*Create`/`*Update` object by hand inside the route body from individually-parsed `Form(...)` parameters, rather than declaring the schema itself as a FastAPI request-body dependency. That means a `pydantic.ValidationError` raised by the new constraints was **not** automatically converted to a 422 by FastAPI's usual `RequestValidationError` handling — it would have propagated as an unhandled exception (500 in production, a raised exception in `TestClient`). Added `schema_validation_error_handler` in `app/main.py` (mirrors FastAPI's default `RequestValidationError` → 422 JSON response shape) to close that gap.

## Tests

Added at least one 422 test per affected Create schema (zero/negative amount) and per name/label field (whitespace-only), across `tests/test_expenses.py`, `test_transfers.py`, `test_goals.py`, `test_credit.py`, `test_assets.py`, `test_goal_contributions.py`, `test_channels.py`, and `test_payout_periods.py`, following each file's existing helper/pattern conventions. No existing test needed its fixture data changed — a scan of the whole suite beforehand confirmed no test creates a `gt=0` field at `0`/negative or a blank name expecting success; the tests that already use `income_amount="0"`/`used="0"` are unaffected since those fields are `ge=0`.

## Validation

```
poetry run ruff check .            # pass
poetry run ruff format --check .   # pass
poetry run mypy app tests          # pass
poetry run djlint app/templates --profile jinja --check   # pass
poetry run pytest                  # 182 passed, 1 failed (test_update_profile_persists_all_fields — pre-existing Windows tzdata/zoneinfo gap, unrelated to this change)
```