### PR TITLE
(fix) normalize email case to prevent split accounts

### DIFF
--- a/alembic/versions/76352e3a5eef_case_insensitive_email_index.py
+++ b/alembic/versions/76352e3a5eef_case_insensitive_email_index.py
@@ -1,0 +1,34 @@
+"""case-insensitive email index
+
+Revision ID: 76352e3a5eef
+Revises: 675bc76494c0
+Create Date: 2026-08-16 08:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '76352e3a5eef'
+down_revision: Union[str, None] = '675bc76494c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Backfill any pre-existing mixed-case emails to lowercase before adding
+    # the unique index below, so two accounts that only differ by casing
+    # (which the app never intentionally created, but the old case-sensitive
+    # constraint didn't prevent) don't make this index un-creatable. Written
+    # as raw SQL rather than op.execute(users.update()...) since this
+    # migration must keep working regardless of what app/models.py looks
+    # like in the future -- see CLAUDE.md's "Models vs. migrations" note.
+    op.execute("UPDATE users SET email = lower(email) WHERE email != lower(email)")
+    op.create_index(
+        "ix_users_email_lower", "users", [sa.text("lower(email)")], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email_lower", table_name="users")

--- a/app/crud.py
+++ b/app/crud.py
@@ -121,11 +121,14 @@ def get_user(db: Session, user_id: int) -> models.User | None:
 
 
 def get_user_by_email(db: Session, email: str) -> models.User | None:
-    return db.scalar(select(models.User).where(models.User.email == email))
+    # Case-insensitive: an OAuth provider's verified email casing isn't
+    # guaranteed to match how the user (or an operator via manage_users.py)
+    # originally typed it -- see issue #71.
+    return db.scalar(select(models.User).where(models.User.email == email.strip().lower()))
 
 
 def create_user(db: Session, email: str) -> models.User:
-    user = models.User(email=email)
+    user = models.User(email=email.strip().lower())
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,15 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, LargeBinary, Numeric, String, UniqueConstraint
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    LargeBinary,
+    Numeric,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -38,6 +47,13 @@ class User(Base):
     onboarding_completed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+
+    # Plain unique=True above only rejects byte-identical duplicates -- app
+    # code always normalizes email to lowercase before read/write (see
+    # crud.get_user_by_email/create_user), but this functional index is a
+    # DB-level backstop against any write path that forgets to (a raw SQL
+    # script, a future admin tool, etc.) -- see issue #71.
+    __table_args__ = (Index("ix_users_email_lower", func.lower(email), unique=True),)
 
 
 class OAuthIdentity(Base):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -331,6 +331,53 @@ def test_oauth_login_auto_links_existing_email_without_key(
         db.close()
 
 
+def test_oauth_login_auto_links_email_with_different_casing(
+    real_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for #71: an operator-created account
+    ("Alice@Example.com", however they happened to type it) must still
+    auto-link when the OAuth provider returns a differently-cased but
+    equivalent verified email -- otherwise this silently creates a second
+    account for the same mailbox instead of linking to the existing one."""
+    user_id = _create_user("Alice@Example.com")
+
+    response = _oauth_login(
+        real_client, monkeypatch, email="alice@example.com", provider_user_id="g-alice"
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/"
+
+    db = TestingSessionLocal()
+    try:
+        identity = crud.get_oauth_identity(db, "google", "g-alice")
+        assert identity is not None
+        assert identity.user_id == user_id
+        # No duplicate account for the same mailbox under a different casing.
+        assert db.query(models.User).filter(models.User.email == "alice@example.com").count() == 1
+    finally:
+        db.close()
+
+
+def test_create_user_stores_email_lowercase() -> None:
+    db = TestingSessionLocal()
+    try:
+        user = crud.create_user(db, "Bob@Example.COM")
+        assert user.email == "bob@example.com"
+    finally:
+        db.close()
+
+
+def test_get_user_by_email_is_case_insensitive() -> None:
+    db = TestingSessionLocal()
+    try:
+        user = crud.create_user(db, "carol@example.com")
+        found = crud.get_user_by_email(db, "CAROL@Example.com")
+        assert found is not None
+        assert found.id == user.id
+    finally:
+        db.close()
+
+
 def test_oauth_login_links_second_provider_to_same_account(
     real_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Fixes #71.

`get_user_by_email`/`create_user` now normalize to lowercase before compare/store, so an OAuth provider's verified email casing doesn't have to exactly match how the account was originally typed (e.g. via `manage_users.py create`) for auto-link to find it. Without this, a casing mismatch silently created a second `User` row for the same mailbox instead of linking to the existing one.

Also adds a functional unique index on `lower(email)` (new migration) as a DB-level backstop against any write path that bypasses `crud.py`'s normalization — the migration lowercases any pre-existing mixed-case rows first so the index can actually be created.

Verified the index approach directly against SQLite (same mechanism the test suite uses via `Base.metadata.create_all`) before adding — a raw duplicate insert differing only by case is correctly rejected. Could not verify the migration itself against a real Postgres locally (Docker daemon isn't running in this environment); reasoned through it carefully and it's a standard functional-index pattern.