### PR TITLE
(feat) add security response headers (CSP, X-Frame-Options, HSTS, Referrer-Policy)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Awaitable, Callable
 
 from fastapi import Depends, FastAPI, Request
 from fastapi.encoders import jsonable_encoder
@@ -56,6 +57,43 @@ app.add_middleware(
     same_site="lax",
     https_only=os.environ.get("VERCEL") == "1",
 )
+
+# CSP audited against this app's actual resource usage (see #73): htmx from
+# unpkg, the compiled Tailwind stylesheet + Google Fonts, and same-origin
+# everything else (channel logos/avatars are served through app routes, not
+# data: URIs). 'unsafe-inline' on script-src/style-src is a real, deliberate
+# gap, not an oversight -- the app relies throughout on inline onclick/
+# onchange/oninput handlers and a few inline style="width: {{ pct }}%"
+# attributes (progress bars, dynamic channel colors) that would need a
+# larger template refactor (nonces don't cover inline *event handler*
+# attributes at all) to remove. Still meaningfully restricts remote script/
+# object/frame sources and exfiltration paths even with that gap.
+_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://unpkg.com; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com; "
+    "img-src 'self'; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
+
+@app.middleware("http")
+async def security_headers(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    response = await call_next(request)
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "same-origin"
+    response.headers["Content-Security-Policy"] = _CSP
+    if os.environ.get("VERCEL") == "1":
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    return response
+
 
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,20 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_security_headers_present_on_every_response(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["Referrer-Policy"] == "same-origin"
+    csp = response.headers["Content-Security-Policy"]
+    assert "default-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+
+
+def test_hsts_only_set_on_vercel(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VERCEL", raising=False)
+    assert "Strict-Transport-Security" not in client.get("/health").headers
+
+    monkeypatch.setenv("VERCEL", "1")
+    assert "max-age" in client.get("/health").headers["Strict-Transport-Security"]


### PR DESCRIPTION
Fixes #73.

Adds a `security_headers` middleware in `app/main.py` setting `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: same-origin`, a CSP, and (Vercel/prod only, matching the existing `https_only` check) `Strict-Transport-Security` on every response.

CSP audited directly against this app's templates rather than guessed:
- `script-src`: `'self' 'unsafe-inline' https://unpkg.com` (htmx is loaded from unpkg; the app relies throughout on inline `onclick`/`onchange`/`oninput` handlers, not a nonce-friendly pattern)
- `style-src`: `'self' 'unsafe-inline' https://fonts.googleapis.com` (Google Fonts stylesheet + a handful of inline `style="width: {{ pct }}%"`/`background: {{ channel.color }}` attributes for progress bars and dynamic channel colors)
- `font-src`: `fonts.gstatic.com` (actual font files referenced by the Google Fonts CSS)
- `img-src 'self'`, `connect-src 'self'`: channel logos/avatars are served through app routes, not `data:` URIs; htmx requests are same-origin
- `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`

The `'unsafe-inline'` gap is real and documented inline — closing it would mean a template-wide refactor away from inline event handler attributes, out of scope for this pass. Still meaningfully restricts remote script/object/frame sources and exfiltration paths.

Verified: ran the app locally (SQLite, no Docker) and curl'd `/login`/`/signup` to confirm they still render 200 with the policy applied. Couldn't check actual browser console CSP violations — no Chrome instance available in this environment — so if anything renders oddly after this ships, the CSP directives are the first thing to check (loosen the specific directive, not `'unsafe-inline'` scope further, before reaching for something broader).