### PR TITLE
(fix) sanitize CSV exports against formula injection

### DIFF
--- a/app/routers/export.py
+++ b/app/routers/export.py
@@ -11,11 +11,25 @@ from app.database import get_db
 router = APIRouter(prefix="/export", tags=["export"])
 
 
+_FORMULA_TRIGGER_CHARS = ("=", "+", "-", "@")
+
+
+def _sanitize_cell(value: object) -> object:
+    # A user-controlled name/label starting with =, +, -, or @ triggers
+    # formula execution when the exported CSV is opened in Excel/Google
+    # Sheets -- prefixing with a leading apostrophe (the standard mitigation)
+    # forces spreadsheet apps to treat it as literal text. Only string cells
+    # can carry this risk; amounts are always numbers. See issue #74.
+    if isinstance(value, str) and value.startswith(_FORMULA_TRIGGER_CHARS):
+        return f"'{value}"
+    return value
+
+
 def _csv_response(rows: list[list[object]], header: list[str], filename: str) -> Response:
     buffer = StringIO()
     writer = csv.writer(buffer)
     writer.writerow(header)
-    writer.writerows(rows)
+    writer.writerows([_sanitize_cell(cell) for cell in row] for row in rows)
     return Response(
         content=buffer.getvalue(),
         media_type="text/csv",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -94,3 +94,24 @@ def test_export_empty_data_returns_header_only(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.text.strip() == "Name,Color,Type"
+
+
+def test_export_channels_csv_sanitizes_formula_injection(client: TestClient) -> None:
+    """Regression test for #74: a channel named starting with =, +, -, or @
+    would otherwise trigger formula execution when the exported CSV is
+    opened in Excel/Google Sheets."""
+    _create_channel(client, "=1+1", "#8a8a8a")
+    _create_channel(client, "+1234", "#111111")
+    _create_channel(client, "-1234", "#222222")
+    _create_channel(client, "@SUM(A1:A1)", "#333333")
+
+    response = client.get("/export/channels.csv")
+
+    assert response.status_code == 200
+    assert "'=1+1" in response.text
+    assert "'+1234" in response.text
+    assert "'-1234" in response.text
+    assert "'@SUM(A1:A1)" in response.text
+    # The raw, unprefixed forms must not appear anywhere in the output.
+    assert "\n=1+1" not in response.text
+    assert ",=1+1" not in response.text


### PR DESCRIPTION
Fixes #74.

`app/routers/export.py` wrote user-controlled name fields (channel/expense/etc.) directly into CSV cells with no sanitization. A name starting with `=`, `+`, `-`, or `@` triggers formula execution in Excel/Google Sheets when the exported CSV is opened.

Fix: prefix any such cell with a leading `'` (the standard mitigation) before writing, applied generically inside `_csv_response` so it covers every export route (channels/payout-periods/expenses/transfers) rather than patching each one individually. Only string cells are checked — amounts are always numbers, never at risk.

New test covers all four trigger characters and confirms the raw unprefixed form never appears in the output.