### PR TITLE
(fix) verify tailwindcss binary checksum in vercel.json build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.0.0/tailwindcss-linux-x64 && chmod +x tailwindcss && ./tailwindcss -i app/static/css/input.css -o app/static/css/style.css",
+  "buildCommand": "curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.0.0/tailwindcss-linux-x64 && echo '09c1a5997d68f5e0127d9737593e7dc658fc96dc1851d782a78983d0d6a03c7c  tailwindcss' | sha256sum -c - && chmod +x tailwindcss && ./tailwindcss -i app/static/css/input.css -o app/static/css/style.css",
   "regions": ["sin1"],
   "git": {
     "deploymentEnabled": {


### PR DESCRIPTION
Fixes #75.

Adds a `sha256sum -c` check against the downloaded `tailwindcss-linux-x64` v4.0.0 binary before `chmod +x`/execute — the build now fails loudly on a hash mismatch instead of silently running whatever was downloaded from that URL.

Hash verified by actually downloading the pinned release asset and computing it locally (`09c1a5997d68f5e0127d9737593e7dc658fc96dc1851d782a78983d0d6a03c7c`), cross-checked against the release asset's reported file size via the GitHub API (`133612758` bytes, matches exactly) — not copied from an unverified source.

Note: `Dockerfile` downloads the exact same binary the exact same way and has the same gap. Left out of this PR since issue #75 scopes specifically to `vercel.json` — happy to do a quick fast-follow for the Dockerfile if wanted.