### PR TITLE
(fix) add aria-label to rail nav items so collapsed state keeps accessible names

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,8 @@
         {% set nav_items = [('/', 'Overview', 'M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z'), ('/expenses', 'Expenses', 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z'), ('/cashflow', 'Cash Flow', 'M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5'), ('/goals', 'Goals', 'M3 3v1.5M3 21v-6m0 0l2.77-.693a9 9 0 016.208.682l.108.054a9 9 0 006.086.71l3.114-.732a48.524 48.524 0 01-.005-10.499l-3.11.732a9 9 0 01-6.085-.711l-.108-.054a9 9 0 00-6.208-.682L3 4.5M3 15V4.5'), ('/credit', 'Credit', 'M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z'), ('/assets', 'Assets', 'M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75z')] %}
         {% for href, label, icon_path in nav_items %}
           <a class="tab{{ ' tab-active' if request.url.path == href else '' }}"
-             href="{{ href }}">
+             href="{{ href }}"
+             aria-label="{{ label }}">
             <svg class="tab-icon"
                  viewBox="0 0 24 24"
                  fill="none"
@@ -47,7 +48,8 @@
           </a>
         {% endfor %}
         <a class="tab mt-auto{{ ' tab-active' if request.url.path == '/account' else '' }}"
-           href="/account">
+           href="/account"
+           aria-label="Account">
           {% if current_user and current_user.avatar_data %}
             <img class="tab-icon rounded-full object-cover"
                  src="/account/avatar"
@@ -65,7 +67,8 @@
         </a>
         <button type="button"
                 id="theme-toggle"
-                class="tab w-full text-left bg-transparent cursor-pointer js-theme-toggle">
+                class="tab w-full text-left bg-transparent cursor-pointer js-theme-toggle"
+                aria-label="Dark mode">
           <svg class="tab-icon js-theme-icon-light"
                viewBox="0 0 24 24"
                fill="none"
@@ -87,7 +90,8 @@
                  name="csrf_token"
                  value="{{ request.session.csrf_token }}">
           <button type="submit"
-                  class="tab w-full text-left bg-transparent cursor-pointer">
+                  class="tab w-full text-left bg-transparent cursor-pointer"
+                  aria-label="Log out">
             <svg class="tab-icon"
                  viewBox="0 0 24 24"
                  fill="none"
@@ -255,6 +259,7 @@
       const lightIcons = document.querySelectorAll(".js-theme-icon-light");
       const darkIcons = document.querySelectorAll(".js-theme-icon-dark");
       const themeLabels = document.querySelectorAll(".js-theme-label");
+      const themeToggles = document.querySelectorAll(".js-theme-toggle");
 
       function effectiveTheme() {
         const stored = localStorage.getItem("theme");
@@ -269,6 +274,11 @@
         lightIcons.forEach((el) => el.classList.toggle("hidden", isDark));
         darkIcons.forEach((el) => el.classList.toggle("hidden", !isDark));
         themeLabels.forEach((el) => { el.textContent = isDark ? "Light mode" : "Dark mode"; });
+        // Keep the accessible name in sync too -- the rail's .tab-label span
+        // (which themeLabels above updates) is hidden while the rail is
+        // collapsed, so the button's own aria-label is what a screen reader
+        // actually announces at that point (see #76).
+        themeToggles.forEach((el) => { el.setAttribute("aria-label", isDark ? "Light mode" : "Dark mode"); });
       }
 
       function toggleTheme() {

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -43,3 +43,17 @@ def test_plain_account_request_returns_full_page(client: TestClient) -> None:
     assert 'id="account-page"' in response.text
     assert "<html" in response.text
     assert 'id="rail"' in response.text
+
+
+def test_rail_nav_items_have_accessible_names(client: TestClient) -> None:
+    """Regression test for #76: the rail's .tab-label spans are hidden via
+    JS while the rail is collapsed, so each nav item/theme-toggle/logout
+    button needs its own aria-label to keep an accessible name regardless of
+    collapsed state."""
+    response = client.get("/")
+    text = response.text
+
+    for label in ("Overview", "Expenses", "Cash Flow", "Goals", "Credit", "Assets", "Account"):
+        assert f'aria-label="{label}"' in text
+    assert 'aria-label="Dark mode"' in text
+    assert 'aria-label="Log out"' in text


### PR DESCRIPTION
Fixes #76.

Adds `aria-label` to each rail nav `<a class="tab">`, the account link, the theme-toggle button, and the logout button, matching their visible label text — independent of the `.tab-label` span's `display: none` toggle when the rail is collapsed.

The theme toggle's label also changes at runtime (Dark mode / Light mode), so `applyTheme()` now keeps `aria-label` in sync alongside the existing `.js-theme-label` textContent update — otherwise the aria-label would freeze on whatever was server-rendered.

Scoped to the rail nav specifically (the mobile "More" sheet's `.sheet-item`s already show visible text unconditionally, so they don't have this collapse-related gap).