### PR TITLE
(fix) add label associations to every form field app-wide

### DIFF
--- a/app/templates/partials/account_page.html
+++ b/app/templates/partials/account_page.html
@@ -42,9 +42,11 @@
         </div>
       </div>
       <div class="flex-1 min-w-0">
-        <span class="text-[11px] font-bold uppercase tracking-wide text-ink-soft mb-1.5 block">Display name</span>
+        <label for="display_name"
+               class="text-[11px] font-bold uppercase tracking-wide text-ink-soft mb-1.5 block">Display name</label>
         <input class="field"
                type="text"
+               id="display_name"
                name="display_name"
                form="profile-form"
                maxlength="100"
@@ -61,8 +63,9 @@
              value="{{ request.session.csrf_token }}">
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
         <div>
-          <span class="text-[11px] font-bold uppercase tracking-wide text-ink-soft mb-1.5 block">Currency</span>
-          <select class="field" name="currency_code">
+          <label for="currency_code"
+                 class="text-[11px] font-bold uppercase tracking-wide text-ink-soft mb-1.5 block">Currency</label>
+          <select class="field" id="currency_code" name="currency_code">
             {% for code, label in currency_options %}
               <option value="{{ code }}"
                       {{ "selected" if current_user.currency_code == code else "" }}>{{ label }}
@@ -71,8 +74,9 @@
           </select>
         </div>
         <div>
-          <span class="text-[11px] font-bold uppercase tracking-wide text-ink-soft mb-1.5 block">Timezone</span>
-          <select class="field" name="timezone">
+          <label for="timezone"
+                 class="text-[11px] font-bold uppercase tracking-wide text-ink-soft mb-1.5 block">Timezone</label>
+          <select class="field" id="timezone" name="timezone">
             <option value="">No timezone set</option>
             {% for tz in timezone_options %}
               <option value="{{ tz }}"

--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -43,7 +43,11 @@
                       hx-target="#assets-page"
                       hx-swap="outerHTML"
                       class="edit-asset-{{ asset.id }} hidden items-center gap-2">
-                  <input class="field" type="text" name="name" value="{{ asset.name }}">
+                  <input class="field"
+                         type="text"
+                         name="name"
+                         aria-label="Name"
+                         value="{{ asset.name }}">
                 </form>
               </td>
               <td class="led-inline led-inline-2" data-label="Channel">
@@ -55,7 +59,10 @@
                   {% endif %}
                 </span>
                 <div class="edit-asset-{{ asset.id }} hidden items-center gap-1">
-                  <select class="field" name="channel_id" form="asset-edit-form-{{ asset.id }}">
+                  <select class="field"
+                          name="channel_id"
+                          form="asset-edit-form-{{ asset.id }}"
+                          aria-label="Channel">
                     <option value="">No channel</option>
                     {% for channel in channels %}
                       <option value="{{ channel.id }}"
@@ -74,6 +81,7 @@
                          step="0.01"
                          name="amount"
                          form="asset-edit-form-{{ asset.id }}"
+                         aria-label="Amount"
                          value="{{ asset.amount }}">
                 </div>
               </td>
@@ -124,10 +132,14 @@
                      name="name"
                      form="add-asset-form"
                      placeholder="Asset name"
+                     aria-label="Asset name"
                      required>
             </td>
             <td class="led-inline led-inline-2" data-label="Channel">
-              <select class="field" name="channel_id" form="add-asset-form">
+              <select class="field"
+                      name="channel_id"
+                      form="add-asset-form"
+                      aria-label="Channel">
                 <option value="">No channel</option>
                 {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
               </select>
@@ -141,6 +153,7 @@
                        name="amount"
                        form="add-asset-form"
                        placeholder="Amount"
+                       aria-label="Amount"
                        required>
               </div>
             </td>

--- a/app/templates/partials/cashflow_page.html
+++ b/app/templates/partials/cashflow_page.html
@@ -160,7 +160,8 @@
                          type="number"
                          step="0.01"
                          value="{{ transfer.amount }}"
-                         data-role="edge-amount">
+                         data-role="edge-amount"
+                         aria-label="Transfer amount">
                 </span>
                 <button type="button"
                         class="icon-btn"
@@ -180,7 +181,8 @@
                          type="number"
                          step="0.01"
                          value="{{ gc.amount }}"
-                         data-role="edge-amount">
+                         data-role="edge-amount"
+                         aria-label="Goal contribution amount">
                 </span>
                 <button type="button"
                         class="icon-btn"

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -44,7 +44,11 @@
                       hx-target="#credit-page"
                       hx-swap="outerHTML"
                       class="edit-credit-{{ line.id }} hidden items-center gap-2">
-                  <input class="field" type="text" name="name" value="{{ line.name }}">
+                  <input class="field"
+                         type="text"
+                         name="name"
+                         aria-label="Name"
+                         value="{{ line.name }}">
                 </form>
               </td>
               <td class="led-inline led-inline-2" data-label="Channel">
@@ -56,7 +60,10 @@
                   {% endif %}
                 </span>
                 <div class="edit-credit-{{ line.id }} hidden items-center gap-1">
-                  <select class="field" name="channel_id" form="credit-edit-form-{{ line.id }}">
+                  <select class="field"
+                          name="channel_id"
+                          form="credit-edit-form-{{ line.id }}"
+                          aria-label="Channel">
                     <option value="">No channel</option>
                     {% for channel in channels %}
                       <option value="{{ channel.id }}"
@@ -75,6 +82,7 @@
                          step="0.01"
                          name="limit"
                          form="credit-edit-form-{{ line.id }}"
+                         aria-label="Limit"
                          value="{{ line.limit }}">
                 </div>
               </td>
@@ -87,6 +95,7 @@
                          step="0.01"
                          name="used"
                          form="credit-edit-form-{{ line.id }}"
+                         aria-label="Used"
                          value="{{ line.used }}">
                 </div>
               </td>
@@ -150,10 +159,14 @@
                      name="name"
                      form="add-credit-form"
                      placeholder="Credit line name"
+                     aria-label="Credit line name"
                      required>
             </td>
             <td class="led-inline led-inline-2" data-label="Channel">
-              <select class="field" name="channel_id" form="add-credit-form">
+              <select class="field"
+                      name="channel_id"
+                      form="add-credit-form"
+                      aria-label="Channel">
                 <option value="">No channel</option>
                 {% for channel in channels %}
                   <option value="{{ channel.id }}">{{ channel.name }}</option>
@@ -169,6 +182,7 @@
                        name="limit"
                        form="add-credit-form"
                        placeholder="Limit"
+                       aria-label="Limit"
                        required>
               </div>
             </td>
@@ -180,7 +194,8 @@
                        step="0.01"
                        name="used"
                        form="add-credit-form"
-                       placeholder="0">
+                       placeholder="0"
+                       aria-label="Used">
               </div>
             </td>
             <td></td>

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -73,15 +73,21 @@
                       hx-swap="outerHTML"
                       hx-encoding="multipart/form-data"
                       class="edit-channel-{{ channel.id }} hidden items-center gap-2 flex-wrap">
-                  <input class="field" type="text" name="name" value="{{ channel.name }}">
+                  <input class="field"
+                         type="text"
+                         name="name"
+                         aria-label="Name"
+                         value="{{ channel.name }}">
                   <input class="w-10 h-8 rounded border border-line cursor-pointer"
                          type="color"
                          name="color"
+                         aria-label="Color"
                          value="{{ channel.color }}">
                   <input class="field text-xs"
                          type="file"
                          name="logo"
-                         accept="image/png,image/jpeg,image/webp,image/gif">
+                         accept="image/png,image/jpeg,image/webp,image/gif"
+                         aria-label="Logo">
                   {% if channel.logo_data %}
                     <button type="button"
                             class="icon-btn hover:bg-rust-soft hover:text-rust"
@@ -103,7 +109,8 @@
                 <div class="edit-channel-{{ channel.id }} hidden items-center gap-1">
                   <select class="field"
                           name="channel_type"
-                          form="channel-edit-form-{{ channel.id }}">
+                          form="channel-edit-form-{{ channel.id }}"
+                          aria-label="Type">
                     <option value="">No type</option>
                     {% for ct in channel_types %}
                       <option value="{{ ct }}"
@@ -197,14 +204,19 @@
              name="name"
              form="add-channel-form"
              placeholder="Channel name"
+             aria-label="Channel name"
              oninput="this.form.elements.badge_label.value = ''"
              required>
       <input class="w-10 h-8 rounded border border-line cursor-pointer"
              type="color"
              name="color"
              form="add-channel-form"
-             value="#8a8a8a">
-      <select class="field w-40" name="channel_type" form="add-channel-form">
+             value="#8a8a8a"
+             aria-label="Color">
+      <select class="field w-40"
+              name="channel_type"
+              form="add-channel-form"
+              aria-label="Type">
         <option value="">No type</option>
         {% for ct in channel_types %}<option value="{{ ct }}">{{ ct }}</option>{% endfor %}
       </select>
@@ -213,7 +225,8 @@
              name="logo"
              form="add-channel-form"
              accept="image/png,image/jpeg,image/webp,image/gif"
-             title="Optional custom logo image (overrides the preset badge)">
+             title="Optional custom logo image (overrides the preset badge)"
+             aria-label="Logo">
       <input type="hidden" name="badge_label" form="add-channel-form">
       <div class="flex items-center gap-2">
         <button class="add-btn mt-0" type="submit" form="add-channel-form">Add</button>
@@ -266,6 +279,7 @@
                          step="0.01"
                          name="income_amount"
                          form="edit-payout-form-{{ period.id }}"
+                         aria-label="Income"
                          value="{{ period.income_amount }}">
                 </div>
               </td>
@@ -280,7 +294,8 @@
                 <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
                   <select class="field"
                           name="receiving_channel_id"
-                          form="edit-payout-form-{{ period.id }}">
+                          form="edit-payout-form-{{ period.id }}"
+                          aria-label="Receiving channel">
                     <option value="">No channel</option>
                     {% for channel in channels %}
                       <option value="{{ channel.id }}"
@@ -340,6 +355,7 @@
                      name="label"
                      form="add-payout-form"
                      placeholder="e.g. 15th"
+                     aria-label="Label"
                      required>
             </td>
             <td class="num" data-label="Income">
@@ -350,11 +366,15 @@
                        step="0.01"
                        name="income_amount"
                        form="add-payout-form"
-                       placeholder="Income">
+                       placeholder="Income"
+                       aria-label="Income">
               </div>
             </td>
             <td class="text-right" data-label="Receiving channel">
-              <select class="field" name="receiving_channel_id" form="add-payout-form">
+              <select class="field"
+                      name="receiving_channel_id"
+                      form="add-payout-form"
+                      aria-label="Receiving channel">
                 <option value="">No channel</option>
                 {% for channel in channels %}
                   <option value="{{ channel.id }}"
@@ -386,6 +406,7 @@
              name="q"
              value="{{ q }}"
              placeholder="Filter by name&hellip;"
+             aria-label="Filter expenses by name"
              hx-preserve
              hx-get="/expenses"
              hx-trigger="keyup changed delay:300ms, search"
@@ -456,12 +477,14 @@
                      name="name"
                      form="add-expense-form"
                      placeholder="Expense name"
+                     aria-label="Expense name"
                      required>
             </td>
             <td class="led-inline led-inline-2" data-label="Payout">
               <select class="field"
                       name="payout_period_id"
                       form="add-expense-form"
+                      aria-label="Payout period"
                       required>
                 {% for period in payout_periods %}
                   <option value="{{ period.id }}"
@@ -472,7 +495,11 @@
               </select>
             </td>
             <td class="led-inline led-inline-2" data-label="Channel">
-              <select class="field" name="channel_id" form="add-expense-form" required>
+              <select class="field"
+                      name="channel_id"
+                      form="add-expense-form"
+                      aria-label="Channel"
+                      required>
                 {% for channel in channels %}
                   <option value="{{ channel.id }}"
                           {{ "selected" if onboarding_step == 3 and channel.id == onboarding_default_expense_channel_id else "" }}>
@@ -488,7 +515,8 @@
                      max="31"
                      name="due_day"
                      form="add-expense-form"
-                     placeholder="Day">
+                     placeholder="Day"
+                     aria-label="Due day">
             </td>
             <td class="num led-inline led-inline-2" data-label="Amount">
               <div class="flex items-center justify-end gap-1">
@@ -499,6 +527,7 @@
                        name="amount"
                        form="add-expense-form"
                        placeholder="Amount"
+                       aria-label="Amount"
                        required>
               </div>
             </td>

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -46,7 +46,11 @@
                       hx-target="#goals-page"
                       hx-swap="outerHTML"
                       class="edit-goal-{{ goal.id }} hidden items-center gap-2">
-                  <input class="field" type="text" name="name" value="{{ goal.name }}">
+                  <input class="field"
+                         type="text"
+                         name="name"
+                         aria-label="Name"
+                         value="{{ goal.name }}">
                 </form>
               </td>
               <td data-label="Channel">
@@ -58,7 +62,10 @@
                   {% endif %}
                 </span>
                 <div class="edit-goal-{{ goal.id }} hidden items-center gap-1">
-                  <select class="field" name="channel_id" form="goal-edit-form-{{ goal.id }}">
+                  <select class="field"
+                          name="channel_id"
+                          form="goal-edit-form-{{ goal.id }}"
+                          aria-label="Channel">
                     <option value="">No channel</option>
                     {% for channel in channels %}
                       <option value="{{ channel.id }}"
@@ -77,6 +84,7 @@
                          step="0.01"
                          name="target"
                          form="goal-edit-form-{{ goal.id }}"
+                         aria-label="Target"
                          value="{{ goal.target }}">
                 </div>
               </td>
@@ -94,6 +102,7 @@
                          min="1"
                          name="months"
                          form="goal-edit-form-{{ goal.id }}"
+                         aria-label="Months"
                          value="{{ goal.months }}">
                 </div>
               </td>
@@ -164,10 +173,14 @@
                      name="name"
                      form="add-goal-form"
                      placeholder="Goal name"
+                     aria-label="Goal name"
                      required>
             </td>
             <td data-label="Channel">
-              <select class="field" name="channel_id" form="add-goal-form">
+              <select class="field"
+                      name="channel_id"
+                      form="add-goal-form"
+                      aria-label="Channel">
                 <option value="">No channel</option>
                 {% for channel in channels %}<option value="{{ channel.id }}">{{ channel.name }}</option>{% endfor %}
               </select>
@@ -181,6 +194,7 @@
                        name="target"
                        form="add-goal-form"
                        placeholder="Target"
+                       aria-label="Target"
                        required>
               </div>
             </td>
@@ -192,7 +206,8 @@
                        step="0.01"
                        name="allocated"
                        form="add-goal-form"
-                       placeholder="0">
+                       placeholder="0"
+                       aria-label="Allocated">
               </div>
             </td>
             <td class="num led-inline led-inline-3" data-label="Months">
@@ -202,7 +217,8 @@
                      min="1"
                      name="months"
                      form="add-goal-form"
-                     placeholder="1">
+                     placeholder="1"
+                     aria-label="Months">
             </td>
             <td>
               <label class="flex items-center gap-1.5 text-[11px] text-ink-soft">

--- a/app/templates/partials/signup_key_section.html
+++ b/app/templates/partials/signup_key_section.html
@@ -8,6 +8,7 @@
                name="invite_key"
                value="{{ invite_key or '' }}"
                placeholder="XXXX-XXXX-XXXX"
+               aria-label="Invite key"
                required
                autofocus
                hx-get="/signup/check-key"

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -59,6 +59,29 @@ def test_rail_nav_items_have_accessible_names(client: TestClient) -> None:
     assert 'aria-label="Log out"' in text
 
 
+def test_form_fields_have_accessible_names(client: TestClient) -> None:
+    """Regression test for #78: every form field's 'label' was a styled
+    <span> positioned near the input with no programmatic association at
+    all (grep -rn '<label for=' app/templates returned zero matches).
+    Account page fields now use real <label for>; table/add-row fields
+    (which already show their label via the column <th>/data-label) use
+    aria-label instead, since a second visible label there would be
+    redundant -- spot-check a representative field on each affected page."""
+    account = client.get("/account").text
+    assert 'for="display_name"' in account
+    assert 'for="currency_code"' in account
+    assert 'for="timezone"' in account
+
+    expenses = client.get("/expenses").text
+    assert 'aria-label="Channel name"' in expenses
+    assert 'aria-label="Label"' in expenses
+    assert 'aria-label="Expense name"' in expenses
+
+    assert 'aria-label="Asset name"' in client.get("/assets").text
+    assert 'aria-label="Credit line name"' in client.get("/credit").text
+    assert 'aria-label="Goal name"' in client.get("/goals").text
+
+
 def test_confirm_and_alert_modals_have_dialog_semantics(client: TestClient) -> None:
     """Regression test for #77: the confirm/alert modals -- used for every
     destructive-delete confirmation and error alert app-wide -- previously


### PR DESCRIPTION
Fixes #78.

`grep -rn '<label for=' app/templates` returned zero matches — every field's 'label' was a styled `<span>` positioned near the input with no programmatic association, systemic across the whole app per the issue.

- **Account page** (a plain vertical form, the issue's given example): converted the 3 spans to real `<label for=...>` elements, adding matching `id`s to `display_name`/`currency_code`/`timezone`.
- **Every table/add-row field** across Channels, Payout Periods, Expenses, Assets, Credit lines, and Goals: added `aria-label` matching the column's label text. These already show their label visually via the column `<th>`/`data-label` attribute, so a second visible `<label>` per cell would be redundant clutter — `aria-label` is a valid WCAG accessible-name technique for exactly this case.
- **Cash Flow canvas**'s inline transfer/goal-contribution amount edits and the **signup invite-key field** (no visible label at all): `aria-label` too.

Caught and fixed a regression while implementing this: several existing tests use a `value="...">` regex pattern that assumes `value` is a field's last attribute before the tag closes — appending `aria-label` after `value` on edit-row fields broke that assumption across ~10 tests. Fixed by ordering `aria-label` before `value` consistently; full suite is green (195 passed).