### PR TITLE
(chore) dedupe trivial owned-delete boilerplate, drop dead .pill-rust CSS

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -82,6 +82,16 @@ def _require_owned(
         raise OwnershipError(f"{label} not found.")
 
 
+def _delete_owned(db: Session, model: type[Any], id_: int, user_id: int | None) -> None:
+    """Delete-if-owned for entities with no extra cleanup/validation on
+    delete (contrast delete_channel/delete_payout_period's in-use checks or
+    delete_goal's child cleanup, which stay bespoke)."""
+    row = _owned(db, model, id_, user_id)
+    if row is not None:
+        db.delete(row)
+        db.commit()
+
+
 # --- Users --------------------------------------------------------------------
 
 # (code, label) pairs for the Account page's currency <select>.
@@ -531,10 +541,7 @@ def create_expense(db: Session, data: schemas.ExpenseCreate, user_id: int | None
 
 
 def delete_expense(db: Session, expense_id: int, user_id: int) -> None:
-    expense = _owned(db, models.Expense, expense_id, user_id)
-    if expense is not None:
-        db.delete(expense)
-        db.commit()
+    _delete_owned(db, models.Expense, expense_id, user_id)
 
 
 # --- Transfers ------------------------------------------------------------------
@@ -584,10 +591,7 @@ def update_transfer(
 
 
 def delete_transfer(db: Session, transfer_id: int, user_id: int) -> None:
-    transfer = _owned(db, models.Transfer, transfer_id, user_id)
-    if transfer is not None:
-        db.delete(transfer)
-        db.commit()
+    _delete_owned(db, models.Transfer, transfer_id, user_id)
 
 
 # --- Goal contributions -------------------------------------------------------
@@ -1050,10 +1054,7 @@ def update_asset(
 
 
 def delete_asset(db: Session, asset_id: int, user_id: int) -> None:
-    asset = _owned(db, models.Asset, asset_id, user_id)
-    if asset is not None:
-        db.delete(asset)
-        db.commit()
+    _delete_owned(db, models.Asset, asset_id, user_id)
 
 
 def assets_page_data(db: Session, user_id: int) -> dict:
@@ -1225,10 +1226,7 @@ def update_credit_line(
 
 
 def delete_credit_line(db: Session, credit_line_id: int, user_id: int) -> None:
-    credit_line = _owned(db, models.CreditLine, credit_line_id, user_id)
-    if credit_line is not None:
-        db.delete(credit_line)
-        db.commit()
+    _delete_owned(db, models.CreditLine, credit_line_id, user_id)
 
 
 def credit_utilization(credit_line: models.CreditLine) -> dict:

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -234,9 +234,6 @@
   .pill-gold {
     @apply bg-gold-soft text-gold;
   }
-  .pill-rust {
-    @apply bg-rust-soft text-rust;
-  }
 
   .led {
     @apply w-full min-w-max table-fixed text-[13.5px] border-collapse;


### PR DESCRIPTION
Fixes #81.

**Duplicated delete boilerplate**: `delete_expense`, `delete_transfer`, `delete_asset`, and `delete_credit_line` were byte-identical 4-line bodies (`_owned` lookup → delete → commit) — extracted a `_delete_owned(db, model, id_, user_id)` helper mirroring the existing `_owned`/`_require_owned` pair. (The issue named `delete_asset`/`delete_credit_line` as examples of "several other simple deletes" — `delete_expense`/`delete_transfer` turned out to match the exact same shape, so included them too.) `delete_channel`/`delete_payout_period` (in-use checks) and `delete_goal` (child cleanup) keep their bespoke bodies per the issue.

**Dead CSS**: removed `.pill-rust` (zero references anywhere in templates/JS/Python, confirmed via grep before deleting).

No behavior change — same 195 tests pass, and I compiled `input.css` locally with the real tailwindcss binary to confirm it still builds cleanly with `.pill-rust` gone from the output.