### PR TITLE
(chore) extract oauth_callback's account-linking decision tree into crud.py

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1,14 +1,17 @@
 import json
+import logging
 import math
 import secrets
 import zoneinfo
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal, NamedTuple
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app import models, schemas
+
+logger = logging.getLogger("app.oauth")
 
 # --- Channels ---------------------------------------------------------------
 
@@ -166,6 +169,55 @@ def create_oauth_identity(
     db.commit()
     db.refresh(identity)
     return identity
+
+
+OAuthLoginError = Literal["already_has_account", "no_account", "invalid_key"]
+
+
+class OAuthLoginResult(NamedTuple):
+    user: models.User | None
+    error: OAuthLoginError | None
+
+
+def resolve_oauth_login(
+    db: Session,
+    provider: str,
+    provider_user_id: str,
+    email: str,
+    pending_invite_key: str,
+    pending_intent: str,
+) -> OAuthLoginResult:
+    """The account-linking decision tree for an OAuth callback: identity
+    lookup -> email match -> auto-link -> invite-key validation -> account
+    creation. Pulled out of app/routers/oauth.py (see issue #82) so the
+    router can stay thin (parse -> call -> respond) like every other router
+    in this app -- this was the one place business logic lived directly in
+    a route handler."""
+    identity = get_oauth_identity(db, provider, provider_user_id)
+    if identity is not None:
+        if pending_intent == "signup":
+            return OAuthLoginResult(user=None, error="already_has_account")
+        return OAuthLoginResult(user=identity.user, error=None)
+
+    existing_user = get_user_by_email(db, email)
+    if existing_user is not None:
+        if pending_intent == "signup":
+            return OAuthLoginResult(user=None, error="already_has_account")
+        create_oauth_identity(db, existing_user, provider, provider_user_id, email)
+        return OAuthLoginResult(user=existing_user, error=None)
+
+    if not pending_invite_key:
+        return OAuthLoginResult(user=None, error="no_account")
+
+    signup_key = get_active_signup_key(db, pending_invite_key)
+    if signup_key is None:
+        return OAuthLoginResult(user=None, error="invalid_key")
+
+    user = create_user(db, email)
+    redeem_signup_key(db, signup_key)
+    logger.info("New account created via signup key: %r", email)
+    create_oauth_identity(db, user, provider, provider_user_id, email)
+    return OAuthLoginResult(user=user, error=None)
 
 
 def update_profile(

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -77,34 +77,20 @@ async def oauth_callback(
             f"Your {provider.capitalize()} account has no verified email we can use.",
         )
 
-    already_has_account_error = _redirect_with_error(
-        "/login", "You already have an account with that email — log in instead."
+    result = crud.resolve_oauth_login(
+        db, provider, provider_user_id, email, pending_invite_key, pending_intent
     )
+    if result.error == "already_has_account":
+        return _redirect_with_error(
+            "/login", "You already have an account with that email — log in instead."
+        )
+    if result.error == "no_account":
+        return _redirect_with_error(
+            "/signup", "No account found for that email. Enter your invite key first."
+        )
+    if result.error == "invalid_key":
+        return _redirect_with_error("/signup", "That invite key is invalid or has expired.")
 
-    identity = crud.get_oauth_identity(db, provider, provider_user_id)
-    if identity is not None:
-        if pending_intent == "signup":
-            return already_has_account_error
-        user = identity.user
-    else:
-        existing_user = crud.get_user_by_email(db, email)
-        if existing_user is not None:
-            if pending_intent == "signup":
-                return already_has_account_error
-            user = existing_user
-            crud.create_oauth_identity(db, user, provider, provider_user_id, email)
-        else:
-            if not pending_invite_key:
-                return _redirect_with_error(
-                    "/signup", "No account found for that email. Enter your invite key first."
-                )
-            signup_key = crud.get_active_signup_key(db, pending_invite_key)
-            if signup_key is None:
-                return _redirect_with_error("/signup", "That invite key is invalid or has expired.")
-            user = crud.create_user(db, email)
-            crud.redeem_signup_key(db, signup_key)
-            logger.info("New account created via signup key: %r", email)
-            crud.create_oauth_identity(db, user, provider, provider_user_id, email)
-
-    start_session(request, user.id, keep_signed_in=pending_keep_signed_in)
+    assert result.user is not None
+    start_session(request, result.user.id, keep_signed_in=pending_keep_signed_in)
     return RedirectResponse(url="/", status_code=303)


### PR DESCRIPTION
Fixes #82.

`oauth_callback` was the one router in the app with real business logic in the handler — the identity lookup → email match → auto-link → invite-key validation → account creation decision tree, mixed with HTTP redirect/error-message construction. Every other router in this app delegates to `crud.py` per CLAUDE.md's "thin router" convention; this one didn't, likely just grew in place.

Adds `crud.resolve_oauth_login(db, provider, provider_user_id, email, pending_invite_key, pending_intent) -> OAuthLoginResult` (a small `NamedTuple`: `user`, `error` — `error` is a `Literal["already_has_account", "no_account", "invalid_key"] | None`) encapsulating the decision tree. `oauth_callback` shrinks back down to parse → call → respond, mapping each error reason to its redirect+message.

Pure refactor, no behavior change — same 195 tests pass unchanged, and the existing OAuth tests (`test_oauth_signup_rejects_missing_key_for_unknown_email`, `_rejects_invalid_key`/`_expired_key`/`_exhausted_key`, `_blocks_already_linked_identity`, `_blocks_matching_email_different_provider`, `_success_creates_account...`, plus the two auto-link tests added for #71) already exercise every branch of this logic, so no new tests needed.