### PR TITLE
(chore) add dependabot config for the pip/Poetry ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    # main only accepts PRs from dev (see CLAUDE.md's Branching section,
+    # enforced by ci.yml's enforce-branch-source job) -- without this,
+    # Dependabot would target the repo's default branch (main) and every PR
+    # it opens would fail that check.
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "(chore)"


### PR DESCRIPTION
Fixes #83.

Adds `.github/dependabot.yml` for the `pip` ecosystem (covers `pyproject.toml`/`poetry.lock` — GitHub's Poetry support lives under this ecosystem name), weekly schedule.

`target-branch` is explicitly set to `dev`, not the repo's default branch (`main`, confirmed via `gh repo view`) — `main` only accepts PRs from `dev` (CLAUDE.md's Branching section, enforced by `enforce-branch-source`), so without this every PR Dependabot opened would immediately fail that check.

**Known limitation, flagged rather than solved here**: a Dependabot PR bumps `poetry.lock` but Dependabot has no way to also run `poetry export` to regenerate `requirements.txt` — so its PRs will fail CI's requirements.txt drift check until someone manually regenerates and pushes it to the PR branch. Worth a follow-up (e.g. a workflow triggered on Dependabot PRs specifically) if this becomes a recurring friction point; out of scope for "add a Dependabot config".