### PR TITLE
(feat) add a simple 'mark as paid' toggle for recurring expenses

### DIFF
--- a/alembic/versions/df0cbf88a4a2_add_expense_paid.py
+++ b/alembic/versions/df0cbf88a4a2_add_expense_paid.py
@@ -1,0 +1,26 @@
+"""add expense paid flag
+
+Revision ID: df0cbf88a4a2
+Revises: 76352e3a5eef
+Create Date: 2026-08-16 10:05:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'df0cbf88a4a2'
+down_revision: Union[str, None] = '76352e3a5eef'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'expenses', sa.Column('paid', sa.Boolean(), nullable=False, server_default=sa.false())
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('expenses', 'paid')

--- a/app/crud.py
+++ b/app/crud.py
@@ -596,6 +596,16 @@ def delete_expense(db: Session, expense_id: int, user_id: int) -> None:
     _delete_owned(db, models.Expense, expense_id, user_id)
 
 
+def set_expense_paid(db: Session, expense_id: int, user_id: int, paid: bool) -> None:
+    """A simple manual paid/unpaid marker -- see Expense.paid's docstring
+    for why this doesn't auto-reset per cycle (issue #85)."""
+    expense = _owned(db, models.Expense, expense_id, user_id)
+    if expense is None:
+        raise OwnershipError("Expense not found.")
+    expense.paid = paid
+    db.commit()
+
+
 # --- Transfers ------------------------------------------------------------------
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -116,6 +116,12 @@ class Expense(Base):
     payout_period_id: Mapped[int] = mapped_column(ForeignKey("payout_periods.id"), nullable=False)
     channel_id: Mapped[int] = mapped_column(ForeignKey("channels.id"), nullable=False)
     due_day: Mapped[int | None] = mapped_column(nullable=True)
+    # A simple manually-maintained marker ("did I pay this bill"), not tied
+    # to a specific cycle -- Expense rows are perpetual templates with no
+    # dated-cycle concept (see issue #84), so this doesn't auto-reset at the
+    # start of a new payout period; the user checks it off, then unchecks it
+    # themselves next cycle. See issue #85.
+    paid: Mapped[bool] = mapped_column(default=False)
 
     payout_period: Mapped[PayoutPeriod] = relationship()
     channel: Mapped[Channel] = relationship()

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -63,6 +63,21 @@ def create_expense(
     return _render_page(request, db, current_user.id)
 
 
+@router.patch("/{expense_id}/paid")
+def update_expense_paid(
+    request: Request,
+    expense_id: int,
+    paid: bool = Form(False),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    try:
+        crud.set_expense_paid(db, expense_id, current_user.id, paid)
+    except crud.OwnershipError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return _render_page(request, db, current_user.id)
+
+
 @router.delete("/{expense_id}")
 def delete_expense(
     request: Request,

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -425,6 +425,7 @@
           <col class="w-24">
           <col class="w-40">
           <col class="w-16">
+          <col class="w-16">
           <col class="w-24">
           <col class="w-36">
         </colgroup>
@@ -434,6 +435,7 @@
             <th>Payout</th>
             <th>Channel</th>
             <th>Due</th>
+            <th>Paid</th>
             <th class="text-right">Amount</th>
             <th></th>
           </tr>
@@ -445,6 +447,16 @@
               <td class="led-inline led-inline-2" data-label="Payout">{{ expense.payout_period.label }}</td>
               <td class="led-inline led-inline-2" data-label="Channel">{{ macros.channel_label(expense.channel) }}</td>
               <td class="led-inline led-inline-2" data-label="Due">{{ expense.due_day or "—" }}</td>
+              <td class="led-inline led-inline-2" data-label="Paid">
+                <input type="checkbox"
+                       aria-label="Paid"
+                       hx-patch="/expenses/{{ expense.id }}/paid"
+                       hx-target="#expenses-page"
+                       hx-swap="outerHTML"
+                       hx-trigger="change"
+                       name="paid"
+                       {{ "checked" if expense.paid else "" }}>
+              </td>
               <td class="num led-inline led-inline-2" data-label="Amount">{{ macros.peso(expense.amount) }}</td>
               <td class="led-actions">
                 <button class="icon-btn"
@@ -457,10 +469,10 @@
               </td>
             </tr>
           {% else %}
-            {{ macros.empty_row(6, 'expenses') }}
+            {{ macros.empty_row(7, 'expenses') }}
           {% endfor %}
           <tr class="tr-add-btn">
-            <td colspan="6">
+            <td colspan="7">
               <button type="button"
                       id="add-expense-trigger"
                       class="add-btn w-20 justify-center disabled:bg-ink-soft disabled:cursor-not-allowed{{ ' hidden' if onboarding_step == 3 else '' }}"
@@ -518,6 +530,7 @@
                      placeholder="Day"
                      aria-label="Due day">
             </td>
+            <td class="led-inline led-inline-2" data-label="Paid"></td>
             <td class="num led-inline led-inline-2" data-label="Amount">
               <div class="flex items-center justify-end gap-1">
                 <span class="text-ink-soft text-sm">{{ currency_symbol }}</span>

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -139,6 +139,43 @@ def test_create_expense_rejects_whitespace_only_name(client: TestClient) -> None
     assert response.status_code == 422
 
 
+def test_mark_expense_paid_and_unpaid(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", channel_id)
+
+    create = client.post(
+        "/expenses",
+        data={
+            "name": "Rent",
+            "amount": "12000",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+    match = re.search(r"/expenses/(\d+)", create.text)
+    assert match is not None
+    expense_id = match.group(1)
+
+    # A brand-new expense starts unpaid.
+    assert re.search(rf'expenses/{expense_id}/paid"[^>]*(?<!checked)>', create.text) is not None
+
+    paid = client.patch(f"/expenses/{expense_id}/paid", data={"paid": "on"})
+    assert paid.status_code == 200
+    assert re.search(rf'expenses/{expense_id}/paid"[^>]*checked>', paid.text) is not None
+
+    # Unchecking a checkbox omits it from the submitted form entirely --
+    # mirrors real browser behavior (see the round_up_to_hundred checkbox
+    # pattern elsewhere in this app).
+    unpaid = client.patch(f"/expenses/{expense_id}/paid", data={})
+    assert unpaid.status_code == 200
+    assert re.search(rf'expenses/{expense_id}/paid"[^>]*checked>', unpaid.text) is None
+
+
+def test_mark_expense_paid_requires_ownership(client: TestClient) -> None:
+    response = client.patch("/expenses/999999/paid", data={"paid": "on"})
+    assert response.status_code == 404
+
+
 def test_expenses_filter_by_name(client: TestClient) -> None:
     channel_id = _create_channel(client, "BPI")
     period_id = _create_payout_period(client, "15th", channel_id)


### PR DESCRIPTION
Fixes #85.

Ships the standalone-toggle scope the issue explicitly calls out as independently useful — full actual-vs-planned amount reconciliation is deferred, since the issue itself says that's more valuable once #84 (dated cycle tracking, itself deferred pending design sign-off — see the mockup posted on that issue) exists.

- `Expense.paid` (bool, default `false`, new migration).
- `PATCH /expenses/{id}/paid` — the first update capability `Expense` has had at all (previously only create/delete existed).
- A checkbox in the Recurring expenses table's new "Paid" column, wired via `hx-patch`/`hx-trigger="change"`, matching the existing `round_up_to_hundred` checkbox pattern used elsewhere in this app.

**Deliberately does not auto-reset per payout period** — documented in the model. `Expense` rows are perpetual templates with no dated-cycle concept, so the app has no way to know "a new cycle started" without #84's schema work. This is a manually-maintained marker (check it off when paid, uncheck it yourself at the start of the next cycle), same spirit as a paper checklist — not a claim of full reconciliation.