### PR TITLE
(feat) pause/skip a recurring expense for one cycle without deleting it

### DIFF
--- a/alembic/versions/f0f32193e46f_add_expense_active.py
+++ b/alembic/versions/f0f32193e46f_add_expense_active.py
@@ -1,0 +1,26 @@
+"""add expense active flag
+
+Revision ID: f0f32193e46f
+Revises: df0cbf88a4a2
+Create Date: 2026-08-16 10:15:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'f0f32193e46f'
+down_revision: Union[str, None] = 'df0cbf88a4a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'expenses', sa.Column('active', sa.Boolean(), nullable=False, server_default=sa.true())
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('expenses', 'active')

--- a/app/crud.py
+++ b/app/crud.py
@@ -606,6 +606,16 @@ def set_expense_paid(db: Session, expense_id: int, user_id: int, paid: bool) -> 
     db.commit()
 
 
+def set_expense_active(db: Session, expense_id: int, user_id: int, active: bool) -> None:
+    """Pause/resume a recurring expense without deleting it -- see
+    Expense.active's docstring (issue #86)."""
+    expense = _owned(db, models.Expense, expense_id, user_id)
+    if expense is None:
+        raise OwnershipError("Expense not found.")
+    expense.active = active
+    db.commit()
+
+
 # --- Transfers ------------------------------------------------------------------
 
 
@@ -994,7 +1004,11 @@ def _all_channel_balances(
     this per period in a loop."""
     channels = list_channels(db, user_id)
     periods = list_payout_periods(db, user_id)
-    all_expenses = list_expenses(db, user_id)
+    # Paused expenses (Expense.active=False) are excluded here -- see #86 --
+    # so they don't count toward the period's balance without needing to
+    # touch the row's identity (still shown, unfiltered, on the Expenses
+    # page itself via list_expenses()).
+    all_expenses = [e for e in list_expenses(db, user_id) if e.active]
 
     carry_in_by_period: dict[int, dict[int, float]] = {}
     balances_by_period: dict[int, list[tuple[models.Channel, float]]] = {}
@@ -1325,7 +1339,7 @@ def overview_page_data(db: Session, user_id: int) -> dict:
     period = next_payout_period(db, user_id)
     upcoming_expenses = (
         sorted(
-            (e for e in list_expenses(db, user_id) if e.payout_period_id == period.id),
+            (e for e in list_expenses(db, user_id) if e.payout_period_id == period.id and e.active),
             key=lambda e: (e.due_day is None, e.due_day),
         )
         if period is not None
@@ -1453,7 +1467,10 @@ def cashflow_page_data(db: Session, user_id: int) -> dict:
     payout_periods = list_payout_periods(db, user_id)
     channels = list_channels(db, user_id)
     goals = list_goals(db, user_id)
-    all_expenses = list_expenses(db, user_id)
+    # Same exclusion as _all_channel_balances -- keeps the canvas's per-
+    # channel expense breakdown consistent with the balances it's shown
+    # alongside (a paused expense doesn't visually deduct here either).
+    all_expenses = [e for e in list_expenses(db, user_id) if e.active]
     payout_period_count = len(payout_periods)
     goal_entries: list[dict[str, Any]] = [
         {"goal": g, "per_payout": goal_payout_amount(g, payout_period_count)} for g in goals

--- a/app/models.py
+++ b/app/models.py
@@ -122,6 +122,11 @@ class Expense(Base):
     # start of a new payout period; the user checks it off, then unchecks it
     # themselves next cycle. See issue #85.
     paid: Mapped[bool] = mapped_column(default=False)
+    # Paused expenses are excluded from channel_balances() (see
+    # _all_channel_balances in crud.py) but the row itself is kept --
+    # cancelling a subscription for one cycle shouldn't mean losing its
+    # channel/amount/history the way deleting it would. See issue #86.
+    active: Mapped[bool] = mapped_column(default=True)
 
     payout_period: Mapped[PayoutPeriod] = relationship()
     channel: Mapped[Channel] = relationship()

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -78,6 +78,21 @@ def update_expense_paid(
     return _render_page(request, db, current_user.id)
 
 
+@router.patch("/{expense_id}/active")
+def update_expense_active(
+    request: Request,
+    expense_id: int,
+    active: bool = Form(False),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    try:
+        crud.set_expense_active(db, expense_id, current_user.id, active)
+    except crud.OwnershipError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return _render_page(request, db, current_user.id)
+
+
 @router.delete("/{expense_id}")
 def delete_expense(
     request: Request,

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -99,6 +99,24 @@
     <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
   </svg>
 {% endmacro %}
+{% macro icon_pause() %}
+  <svg class="w-4 h-4"
+       viewBox="0 0 24 24"
+       fill="none"
+       stroke="currentColor"
+       stroke-width="1.7">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+  </svg>
+{% endmacro %}
+{% macro icon_play() %}
+  <svg class="w-4 h-4"
+       viewBox="0 0 24 24"
+       fill="none"
+       stroke="currentColor"
+       stroke-width="1.7">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+  </svg>
+{% endmacro %}
 {% macro icon_check() %}
   <svg class="w-3.5 h-3.5"
        viewBox="0 0 24 24"

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -443,7 +443,10 @@
         <tbody>
           {% for expense in expenses %}
             <tr>
-              <td class="led-inline led-inline-2" data-label="Name">{{ expense.name }}</td>
+              <td class="led-inline led-inline-2" data-label="Name">
+                {{ expense.name }}
+                {% if not expense.active %}<span class="pill pill-gold">Paused</span>{% endif %}
+              </td>
               <td class="led-inline led-inline-2" data-label="Payout">{{ expense.payout_period.label }}</td>
               <td class="led-inline led-inline-2" data-label="Channel">{{ macros.channel_label(expense.channel) }}</td>
               <td class="led-inline led-inline-2" data-label="Due">{{ expense.due_day or "—" }}</td>
@@ -459,6 +462,13 @@
               </td>
               <td class="num led-inline led-inline-2" data-label="Amount">{{ macros.peso(expense.amount) }}</td>
               <td class="led-actions">
+                <button class="icon-btn"
+                        title="{{ 'Pause' if expense.active else 'Resume' }}"
+                        aria-label="{{ 'Pause' if expense.active else 'Resume' }}"
+                        hx-patch="/expenses/{{ expense.id }}/active"
+                        hx-vals='{"active": "{{ "false" if expense.active else "true" }}"}'
+                        hx-target="#expenses-page"
+                        hx-swap="outerHTML">{{ macros.icon_pause() if expense.active else macros.icon_play() }}</button>
                 <button class="icon-btn"
                         title="Delete"
                         aria-label="Delete"

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -2,6 +2,9 @@ import re
 
 from fastapi.testclient import TestClient
 
+from app import crud, schemas
+from tests.conftest import TEST_USER_ID, TestingSessionLocal
+
 
 def _create_channel(client: TestClient, name: str) -> str:
     response = client.post("/channels", data={"name": name, "color": "#8a8a8a"})
@@ -174,6 +177,77 @@ def test_mark_expense_paid_and_unpaid(client: TestClient) -> None:
 def test_mark_expense_paid_requires_ownership(client: TestClient) -> None:
     response = client.patch("/expenses/999999/paid", data={"paid": "on"})
     assert response.status_code == 404
+
+
+def test_pause_and_resume_expense(client: TestClient) -> None:
+    """Regression test for #86: pausing an expense keeps the row (name still
+    shown, "Paused" pill appears) instead of deleting it."""
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", channel_id)
+
+    create = client.post(
+        "/expenses",
+        data={
+            "name": "Netflix",
+            "amount": "549",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+    match = re.search(r"/expenses/(\d+)", create.text)
+    assert match is not None
+    expense_id = match.group(1)
+    assert "Paused" not in create.text
+
+    paused = client.patch(f"/expenses/{expense_id}/active", data={"active": "false"})
+    assert paused.status_code == 200
+    assert "Netflix" in paused.text
+    assert "Paused" in paused.text
+
+    resumed = client.patch(f"/expenses/{expense_id}/active", data={"active": "true"})
+    assert resumed.status_code == 200
+    assert "Netflix" in resumed.text
+    assert "Paused" not in resumed.text
+
+
+def test_pause_expense_requires_ownership(client: TestClient) -> None:
+    response = client.patch("/expenses/999999/active", data={"active": "false"})
+    assert response.status_code == 404
+
+
+def test_paused_expense_excluded_from_channel_balance() -> None:
+    """A paused expense keeps its row (channel/amount/history intact) but no
+    longer counts toward the period's balance calculation."""
+    db = TestingSessionLocal()
+    try:
+        channel = crud.create_channel(db, schemas.ChannelCreate(name="BPI"), TEST_USER_ID)
+        period = crud.create_payout_period(
+            db,
+            schemas.PayoutPeriodCreate(
+                label="15th", income_amount=1000, receiving_channel_id=channel.id
+            ),
+            TEST_USER_ID,
+        )
+        expense = crud.create_expense(
+            db,
+            schemas.ExpenseCreate(
+                name="Netflix", amount=549, payout_period_id=period.id, channel_id=channel.id
+            ),
+            TEST_USER_ID,
+        )
+
+        balances = {c.id: net for c, net in crud.channel_balances(db, period.id, TEST_USER_ID)}
+        assert balances[channel.id] == 1000 - 549
+
+        crud.set_expense_active(db, expense.id, TEST_USER_ID, False)
+        balances = {c.id: net for c, net in crud.channel_balances(db, period.id, TEST_USER_ID)}
+        assert balances[channel.id] == 1000
+
+        crud.set_expense_active(db, expense.id, TEST_USER_ID, True)
+        balances = {c.id: net for c, net in crud.channel_balances(db, period.id, TEST_USER_ID)}
+        assert balances[channel.id] == 1000 - 549
+    finally:
+        db.close()
 
 
 def test_expenses_filter_by_name(client: TestClient) -> None:


### PR DESCRIPTION
Fixes #86.

A cancelled-this-month subscription or a skipped bill had no representation short of deleting the `Expense` row entirely (losing its channel/amount/history) and re-adding it later.

- `Expense.active` (bool, default `true`, new migration).
- Paused expenses are excluded from `channel_balances()` — and, for consistency, the Cash Flow canvas's per-channel expense breakdown and Overview's "upcoming expenses" banner too, so a paused bill doesn't visually deduct/show as due somewhere while not counting toward the actual balance elsewhere.
- Still shown, unfiltered, on the Expenses page itself with a "Paused" pill next to the name — the row's identity/history is untouched.
- New pause/resume icon-button (`PATCH /expenses/{id}/active`) next to Delete; added `icon_pause()`/`icon_play()` macros.

Same framing as #85: deliberately does **not** auto-reset per payout period. `Expense` rows are perpetual templates with no dated-cycle concept (#84, deferred pending design sign-off), so there's no clean way to know "a new cycle started." This is a manual pause/resume toggle, not a "skip just the next occurrence" mechanism — documented as such in the model.

New tests cover the toggle's UI (row stays, pill appears/disappears) and, at the crud level, that a paused expense's amount is actually excluded from `channel_balances()` and restored on resume.