### PR TITLE
(fix) work around a malformed peso-sign glyph in the served IBM Plex Mono file

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -1,6 +1,32 @@
 @import "tailwindcss";
 @source "../../templates";
 
+/* Google Fonts' served IBM Plex Mono file has a malformed/mis-shaped glyph
+   for U+20B1 (PESO SIGN) that Chrome renders with a stray horizontal line
+   smeared across the *entire* text run, not just the glyph itself -- see
+   issue #49. Confirmed via a standalone repro (isolated font-weight,
+   ligatures/kerning/text-rendering tweaks, and letter-spacing changes all
+   still showed the bug; only substituting a different font for this one
+   codepoint fixed it -- and only when done as a distinct synthetic family
+   inserted ahead of "IBM Plex Mono" in the stack, not as a second
+   same-named @font-face relying on unicode-range disambiguation between
+   two rules sharing a family name, which empirically did NOT take
+   precedence reliably). "PesoFix" has no glyphs of its own outside
+   U+20B1, so every other character in --font-mono falls straight through
+   to the real IBM Plex Mono exactly as before -- no visible font change
+   anywhere else. Falls through further to the theme's own generic
+   "monospace" if none of the local() sources are installed. */
+@font-face {
+  font-family: "PesoFix";
+  src:
+    local("Consolas"),
+    local("SF Mono"),
+    local("Menlo"),
+    local("Cascadia Mono"),
+    local("Courier New");
+  unicode-range: U+20B1;
+}
+
 @layer base {
   input[type="number"] {
     -moz-appearance: textfield;
@@ -29,7 +55,7 @@
      utility, so this token is repointed to the same sans stack as body text
      rather than touching every template that references it. */
   --font-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", monospace;
+  --font-mono: "PesoFix", "IBM Plex Mono", monospace;
 }
 
 /* Dark-mode token overrides -- @theme above only feeds Tailwind's utility


### PR DESCRIPTION
Fixes #49.

Root-caused with an actual browser (had Chrome automation available for this one) rather than guessing: built a standalone repro served over a local HTTP server and visually confirmed the bug, then tested five hypotheses (font-variant-ligatures/kerning/feature-settings reset, text-rendering/font-synthesis tweaks, font-weight, letter-spacing) — none of them changed anything. The Google-Fonts-served IBM Plex Mono file has a malformed glyph for U+20B1 (PESO SIGN) that Chrome renders with a horizontal line smeared across the *entire* text run, not just the glyph itself.

The only thing that worked: substituting a different font for just that codepoint — and only when done as a **separate synthetic family** (`PesoFix`) inserted ahead of `"IBM Plex Mono"` in `--font-mono`. A second `@font-face` reusing the `"IBM Plex Mono"` name and relying on `unicode-range` to disambiguate between the two same-named rules did **not** reliably take precedence when I tested it — worth remembering if this pattern comes up again.

`PesoFix` has no glyphs outside `U+20B1` (`local()` system monospace fonts only, no download), so every other character still renders in the real IBM Plex Mono — verified against the actual compiled CSS and the app's real `.card-value`/`.num` classes, at multiple sizes, with negative amounts, and with a no-peso-sign control to confirm no regression. Falls through to the theme's existing `monospace` generic if none of the `local()` sources are installed.