### PR TITLE
(chore) bump version to 0.2.0-beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finance-tracker"
-version = "0.1.0-beta"
+version = "0.2.0-beta"
 description = "Personal finance tracker (FastAPI + HTMX + Postgres)"
 requires-python = ">=3.12,<4.0"
 dependencies = [


### PR DESCRIPTION
Version bump ahead of the dev -> main release PR.

Since main's current `0.1.0-beta`, `dev` has absorbed several `(feat)` commits (#66 expense due-day, #72 rate limiting, #73 security headers, #85 mark-as-paid, #86 pause/skip expense) alongside a larger number of `(fix)`/`(chore)` ones. Per CLAUDE.md's Versioning section, any `(feat)` commit since the last release means a minor bump with patch reset to 0 → `0.2.0-beta`.

Staying on the pre-release `0.x.y` track rather than bumping to `1.0.0` — that's a separate, deliberate call for whoever decides this is the first real production release, not something this batch of work implies on its own.