### PR TITLE
(feat) add dated cycle history for payout periods

### DIFF
--- a/alembic/versions/21ce9028b3e1_add_payout_cycles.py
+++ b/alembic/versions/21ce9028b3e1_add_payout_cycles.py
@@ -1,0 +1,50 @@
+"""add payout cycles (dated cycle history)
+
+Revision ID: 21ce9028b3e1
+Revises: f0f32193e46f
+Create Date: 2026-08-16 11:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '21ce9028b3e1'
+down_revision: Union[str, None] = 'f0f32193e46f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'payout_cycles',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('payout_period_id', sa.Integer(), nullable=False),
+        sa.Column('label', sa.String(length=50), nullable=False),
+        sa.Column('closed_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('income_amount', sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.Column('receiving_channel_name', sa.String(length=100), nullable=True),
+        sa.ForeignKeyConstraint(['payout_period_id'], ['payout_periods.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'payout_cycle_balances',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('payout_cycle_id', sa.Integer(), nullable=False),
+        sa.Column('channel_name', sa.String(length=100), nullable=False),
+        sa.Column('channel_color', sa.String(length=7), nullable=False),
+        sa.Column('income', sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.Column('transfers_net', sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.Column('expenses_total', sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.Column('net', sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.ForeignKeyConstraint(['payout_cycle_id'], ['payout_cycles.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('payout_cycle_balances')
+    op.drop_table('payout_cycles')

--- a/app/crud.py
+++ b/app/crud.py
@@ -1098,6 +1098,139 @@ def overview_warnings(db: Session, user_id: int) -> list[dict]:
     return entries
 
 
+# --- Payout cycles ----------------------------------------------------------
+
+
+def list_payout_cycles(
+    db: Session, payout_period_id: int, user_id: int
+) -> list[models.PayoutCycle]:
+    stmt = (
+        select(models.PayoutCycle)
+        .where(
+            models.PayoutCycle.payout_period_id == payout_period_id,
+            models.PayoutCycle.user_id == user_id,
+        )
+        .order_by(models.PayoutCycle.closed_at.desc())
+    )
+    return list(db.scalars(stmt))
+
+
+def list_payout_cycle_balances(
+    db: Session, payout_cycle_id: int
+) -> list[models.PayoutCycleBalance]:
+    stmt = (
+        select(models.PayoutCycleBalance)
+        .where(models.PayoutCycleBalance.payout_cycle_id == payout_cycle_id)
+        .order_by(models.PayoutCycleBalance.id)
+    )
+    return list(db.scalars(stmt))
+
+
+def _live_cycle_balances(
+    db: Session, period: models.PayoutPeriod, user_id: int
+) -> list[models.PayoutCycleBalance]:
+    """The live template's current per-channel breakdown, in the exact shape
+    a closed PayoutCycle's balances would be -- shared by close_payout_cycle
+    (persisted) and the "viewing the live template" case in
+    payout_cycle_history_page_data (transient, never db.add()ed, just reused
+    for the template to render both cases identically). `net` includes
+    carry-in from prior periods (the real running balance, same as
+    channel_balances() everywhere else in the app); income/transfers_net/
+    expenses_total describe only this period's own activity, and generally
+    won't sum to `net` on their own -- see PayoutCycleBalance's docstring."""
+    channels = list_channels(db, user_id)
+    transfers = list_transfers(db, period.id, user_id)
+    expenses = [
+        e for e in list_expenses(db, user_id) if e.payout_period_id == period.id and e.active
+    ]
+    net_by_channel_id = {c.id: net for c, net in channel_balances(db, period.id, user_id)}
+
+    balances = []
+    for channel in channels:
+        income = float(period.income_amount) if period.receiving_channel_id == channel.id else 0.0
+        transfers_net = sum(
+            float(t.amount) for t in transfers if t.to_channel_id == channel.id
+        ) - sum(float(t.amount) for t in transfers if t.from_channel_id == channel.id)
+        expenses_total = sum(float(e.amount) for e in expenses if e.channel_id == channel.id)
+        net = net_by_channel_id.get(channel.id, 0.0)
+        if income == 0 and transfers_net == 0 and expenses_total == 0 and net == 0:
+            continue  # skip channels with no activity this cycle
+        balances.append(
+            models.PayoutCycleBalance(
+                channel_name=channel.name,
+                channel_color=channel.color,
+                income=income,
+                transfers_net=transfers_net,
+                expenses_total=expenses_total,
+                net=net,
+            )
+        )
+    return balances
+
+
+def close_payout_cycle(db: Session, payout_period_id: int, user_id: int) -> models.PayoutCycle:
+    """Snapshot the given payout period's current channel balances into a
+    new dated PayoutCycle -- explicit, user-triggered only (no auto-snapshot
+    on some inferred date, since PayoutPeriod has no real calendar anchor).
+    The live template (period, its transfers, its expenses) is left
+    completely untouched -- closing a cycle is purely additive, so there's
+    no data-loss risk and no "did I already close this month" bookkeeping
+    to get wrong. See issue #84."""
+    period = _owned(db, models.PayoutPeriod, payout_period_id, user_id)
+    if period is None:
+        raise OwnershipError("Payout period not found.")
+
+    live_balances = _live_cycle_balances(db, period, user_id)
+
+    cycle = models.PayoutCycle(
+        user_id=user_id,
+        payout_period_id=payout_period_id,
+        label=period.label,
+        income_amount=period.income_amount,
+        receiving_channel_name=(
+            period.receiving_channel.name if period.receiving_channel else None
+        ),
+    )
+    db.add(cycle)
+    db.flush()  # assigns cycle.id, needed for the balance rows below
+
+    for balance in live_balances:
+        balance.payout_cycle_id = cycle.id
+        db.add(balance)
+
+    db.commit()
+    db.refresh(cycle)
+    return cycle
+
+
+def payout_cycle_history_page_data(
+    db: Session, payout_period_id: int, user_id: int, cycle_id: int | None
+) -> dict:
+    period = _owned(db, models.PayoutPeriod, payout_period_id, user_id)
+    if period is None:
+        raise OwnershipError("Payout period not found.")
+
+    cycles = list_payout_cycles(db, payout_period_id, user_id)
+    selected_cycle = None
+    if cycle_id is not None:
+        selected_cycle = next((c for c in cycles if c.id == cycle_id), None)
+        if selected_cycle is None:
+            raise OwnershipError("Cycle not found.")
+
+    balances = (
+        list_payout_cycle_balances(db, selected_cycle.id)
+        if selected_cycle is not None
+        else _live_cycle_balances(db, period, user_id)
+    )
+
+    return {
+        "period": period,
+        "cycles": cycles,
+        "selected_cycle": selected_cycle,
+        "balances": balances,
+    }
+
+
 # --- Assets ---------------------------------------------------------------
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app.routers import (
     oauth,
     onboarding,
     overview,
+    payout_cycles,
     payout_periods,
     transfers,
 )
@@ -141,6 +142,7 @@ app.include_router(auth.router)
 app.include_router(oauth.router)
 app.include_router(channels.router)
 app.include_router(payout_periods.router)
+app.include_router(payout_cycles.router)
 app.include_router(expenses.router)
 app.include_router(transfers.router)
 app.include_router(goal_contributions.router)

--- a/app/models.py
+++ b/app/models.py
@@ -235,3 +235,54 @@ class Asset(Base):
     channel_id: Mapped[int | None] = mapped_column(ForeignKey("channels.id"), nullable=True)
 
     channel: Mapped[Channel | None] = relationship()
+
+
+class PayoutCycle(Base):
+    """A locked, dated snapshot of one occurrence of a PayoutPeriod -- see
+    issue #84. PayoutPeriod itself stays a perpetual, always-editable
+    template (per CLAUDE.md's Domain section); closing a cycle here doesn't
+    touch or clear the period's live transfers/expenses, it just records
+    what channel_balances() computed at that moment so a later edit to the
+    live template can't silently overwrite the only record that ever
+    existed. Deliberately no FK to Channel for the receiving channel (see
+    PayoutCycleBalance below) -- a snapshot is a historical fact and
+    shouldn't block deleting a channel used only in old history, or need
+    updating if that channel is later renamed/recolored."""
+
+    __tablename__ = "payout_cycles"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    payout_period_id: Mapped[int] = mapped_column(ForeignKey("payout_periods.id"), nullable=False)
+    label: Mapped[str] = mapped_column(String(50), nullable=False)
+    closed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+    income_amount: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    receiving_channel_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    payout_period: Mapped[PayoutPeriod] = relationship()
+
+
+class PayoutCycleBalance(Base):
+    """One channel's snapshotted activity within a closed PayoutCycle.
+    channel_name/channel_color are denormalized (not a Channel FK) for the
+    same reason as PayoutCycle.receiving_channel_name above. `net` is the
+    channel's full running balance (as crud.channel_balances() computed it
+    at closure time, including carry-in from prior periods); `income`/
+    `transfers_net`/`expenses_total` describe only this cycle's own
+    activity and generally won't sum to `net` on their own -- both are
+    useful, so both are kept rather than picking one."""
+
+    __tablename__ = "payout_cycle_balances"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    payout_cycle_id: Mapped[int] = mapped_column(ForeignKey("payout_cycles.id"), nullable=False)
+    channel_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    channel_color: Mapped[str] = mapped_column(String(7), nullable=False)
+    income: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
+    transfers_net: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
+    expenses_total: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
+    net: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
+
+    payout_cycle: Mapped[PayoutCycle] = relationship()

--- a/app/routers/payout_cycles.py
+++ b/app/routers/payout_cycles.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from app import crud, models
+from app.auth import get_current_user
+from app.database import get_db
+from app.templating import templates
+
+router = APIRouter(prefix="/payout-periods/{payout_period_id}/cycles", tags=["payout-cycles"])
+
+
+def _render_page(
+    request: Request, db: Session, payout_period_id: int, user_id: int, cycle_id: int | None
+) -> HTMLResponse:
+    try:
+        context = crud.payout_cycle_history_page_data(db, payout_period_id, user_id, cycle_id)
+    except crud.OwnershipError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    template = (
+        "partials/payout_cycle_history_page.html"
+        if request.headers.get("HX-Request")
+        else "payout_cycle_history.html"
+    )
+    return templates.TemplateResponse(request, template, context)
+
+
+@router.get("")
+def index(
+    request: Request,
+    payout_period_id: int,
+    cycle_id: int | None = None,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    return _render_page(request, db, payout_period_id, current_user.id, cycle_id)
+
+
+@router.post("")
+def close_cycle(
+    request: Request,
+    payout_period_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    try:
+        crud.close_payout_cycle(db, payout_period_id, current_user.id)
+    except crud.OwnershipError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return _render_page(request, db, payout_period_id, current_user.id, cycle_id=None)

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -261,6 +261,19 @@
     @apply bg-gold-soft text-gold;
   }
 
+  /* Payout cycle history's clickable timeline of "Live template" + each
+     closed cycle -- see #84. Mirrors .preset-trigger's button-chip
+     language rather than introducing a new visual style. */
+  .cycle-rail {
+    @apply flex items-center gap-2 flex-wrap;
+  }
+  .cycle-chip {
+    @apply inline-flex items-center gap-1.5 text-xs font-semibold text-ink-soft px-3 py-1.5 rounded-full border border-line bg-card cursor-pointer hover:border-accent hover:text-ink transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent;
+  }
+  .cycle-chip-active {
+    @apply bg-accent/10 text-accent border-accent;
+  }
+
   .led {
     @apply w-full min-w-max table-fixed text-[13.5px] border-collapse;
   }

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -13,6 +13,15 @@
           style="background: {{ channel.color }}">{{ initials }}</span>
   {% endif %}
 {% endmacro %}
+{% macro badge_from_name(name, color, size=18) %}
+  {# For contexts with only a denormalized channel name/color, not a real
+     Channel row (e.g. PayoutCycleBalance snapshots, #84) -- no logo/
+     badge_label to fall back through, just the initials treatment. #}
+  {% set words = name.split() %}
+  {% set initials = (words[0][0] ~ (words[1][0] if words|length > 1 else "")) | upper %}
+  <span class="badge {{ 'badge-md' if size >= 18 else 'badge-sm' }}"
+        style="background: {{ color }}">{{ initials }}</span>
+{% endmacro %}
 {% macro channel_name(channel, max_len=18) %}
   <span title="{{ channel.name }}">{{ channel.name|truncate(max_len, True, '…') }}</span>
 {% endmacro %}
@@ -115,6 +124,15 @@
        stroke="currentColor"
        stroke-width="1.7">
     <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+  </svg>
+{% endmacro %}
+{% macro icon_history() %}
+  <svg class="w-3.5 h-3.5"
+       viewBox="0 0 24 24"
+       fill="none"
+       stroke="currentColor"
+       stroke-width="1.7">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
   </svg>
 {% endmacro %}
 {% macro icon_check() %}

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -307,6 +307,10 @@
               </td>
               <td class="led-actions">
                 <div class="view-payout-{{ period.id }} flex items-center gap-1">
+                  <a class="icon-btn"
+                     title="Cycle history"
+                     aria-label="Cycle history"
+                     href="/payout-periods/{{ period.id }}/cycles">{{ macros.icon_history() }}</a>
                   <button type="button"
                           class="icon-btn hover:bg-accent/15 hover:text-accent"
                           title="Edit"

--- a/app/templates/partials/payout_cycle_history_page.html
+++ b/app/templates/partials/payout_cycle_history_page.html
@@ -1,0 +1,88 @@
+{% import "macros.html" as macros with context %}
+<div id="payout-cycle-history-page">
+  <div class="page-head">
+    <div>
+      <div class="page-title">{{ period.label }} &mdash; cycle history</div>
+      <div class="page-sub">
+        <a href="/expenses" class="text-ink-soft hover:text-ink">&larr; Back to Expenses</a>
+      </div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="section-title">
+      Cycles
+      <span class="pill">{{ cycles|length }} closed</span>
+    </div>
+    <div class="cycle-rail">
+      <a href="/payout-periods/{{ period.id }}/cycles"
+         hx-get="/payout-periods/{{ period.id }}/cycles"
+         hx-target="#payout-cycle-history-page"
+         hx-swap="outerHTML"
+         hx-push-url="true"
+         class="cycle-chip{{ ' cycle-chip-active' if selected_cycle is none else '' }}">Live template</a>
+      {% for cycle in cycles %}
+        <a href="/payout-periods/{{ period.id }}/cycles?cycle_id={{ cycle.id }}"
+           hx-get="/payout-periods/{{ period.id }}/cycles?cycle_id={{ cycle.id }}"
+           hx-target="#payout-cycle-history-page"
+           hx-swap="outerHTML"
+           hx-push-url="true"
+           class="cycle-chip{{ ' cycle-chip-active' if selected_cycle and selected_cycle.id == cycle.id else '' }}">
+          {{ cycle.closed_at.strftime("%b %d, %Y") }}
+        </a>
+      {% endfor %}
+    </div>
+    {% if not cycles %}
+      <p class="text-sm text-ink-soft mt-3">
+        No cycles closed yet &mdash; closing one locks today's balances as a dated record you can look back on later, without changing the live template below.
+      </p>
+    {% endif %}
+  </div>
+  <div class="section">
+    <div class="section-title">
+      {% if selected_cycle %}
+        {{ selected_cycle.closed_at.strftime("%B %d, %Y") }}
+        <span class="pill pill-gold">Snapshot &middot; locked</span>
+      {% else %}
+        Live template
+        <span class="pill">Editable</span>
+      {% endif %}
+    </div>
+    <div class="table-wrap">
+      <table class="led">
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th class="text-right">Income</th>
+            <th class="text-right">Transfers</th>
+            <th class="text-right">Expenses</th>
+            <th class="text-right">Net</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for balance in balances %}
+            <tr>
+              <td>
+                {{ macros.badge_from_name(balance.channel_name, balance.channel_color) }}
+                {{ balance.channel_name }}
+              </td>
+              <td class="num">{{ macros.peso(balance.income) }}</td>
+              <td class="num">{{ macros.peso(balance.transfers_net) }}</td>
+              <td class="num">{{ macros.peso(balance.expenses_total) }}</td>
+              <td class="num{{ ' card-value-neg' if balance.net < 0 else '' }}">{{ macros.peso(balance.net) }}</td>
+            </tr>
+          {% else %}
+            {{ macros.empty_row(5, 'channel activity') }}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% if not selected_cycle %}
+      <form hx-post="/payout-periods/{{ period.id }}/cycles"
+            hx-target="#payout-cycle-history-page"
+            hx-swap="outerHTML"
+            hx-confirm="Close this cycle? This locks today's balances as a dated record for {{ period.label }} — it won't change the live template.">
+        <button type="submit" class="add-btn mt-3">Close this cycle</button>
+      </form>
+    {% endif %}
+  </div>
+</div>

--- a/app/templates/payout_cycle_history.html
+++ b/app/templates/payout_cycle_history.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block content %}
+  {% include "partials/payout_cycle_history_page.html" %}
+{% endblock content %}

--- a/tests/test_payout_cycles.py
+++ b/tests/test_payout_cycles.py
@@ -1,0 +1,180 @@
+import re
+
+from fastapi.testclient import TestClient
+
+from app import crud, schemas
+from tests.conftest import TEST_USER_ID, TestingSessionLocal
+
+
+def _create_channel(client: TestClient, name: str) -> str:
+    response = client.post("/channels", data={"name": name, "color": "#8a8a8a"})
+    # Channels are listed alphabetically, so grabbing the first "/channels/{id}"
+    # match in the page breaks once more than one channel exists. Anchor the
+    # match to this channel's own row by starting from its name input.
+    match = re.search(rf'value="{re.escape(name)}">.*?/channels/(\d+)"', response.text, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _create_payout_period(client: TestClient, label: str, income: str, channel_id: str) -> str:
+    response = client.post(
+        "/payout-periods",
+        data={"label": label, "income_amount": income, "receiving_channel_id": channel_id},
+    )
+    matches = re.findall(r"/payout-periods/(\d+)", response.text)
+    assert matches
+    return matches[-1]
+
+
+def test_history_page_shows_live_template_with_no_cycles_closed(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", "1000", channel_id)
+
+    response = client.get(f"/payout-periods/{period_id}/cycles")
+    assert response.status_code == 200
+    assert "15th" in response.text
+    assert "Live template" in response.text
+    assert "0 closed" in response.text
+    assert "1,000.00" in response.text
+
+
+def test_close_cycle_creates_a_dated_snapshot(client: TestClient) -> None:
+    a = _create_channel(client, "Channel A")
+    b = _create_channel(client, "Channel B")
+    period_id = _create_payout_period(client, "15th", "1000", a)
+
+    client.post(
+        "/transfers",
+        data={
+            "payout_period_id": period_id,
+            "from_channel_id": a,
+            "to_channel_id": b,
+            "amount": "300",
+        },
+    )
+    client.post(
+        "/expenses",
+        data={
+            "name": "Rent",
+            "amount": "100",
+            "payout_period_id": period_id,
+            "channel_id": a,
+        },
+    )
+
+    response = client.post(f"/payout-periods/{period_id}/cycles")
+    assert response.status_code == 200
+    assert "1 closed" in response.text
+
+    cycle_match = re.search(r"cycle_id=(\d+)", response.text)
+    assert cycle_match is not None
+    cycle_id = cycle_match.group(1)
+
+    snapshot = client.get(f"/payout-periods/{period_id}/cycles", params={"cycle_id": cycle_id})
+    assert snapshot.status_code == 200
+    assert "Snapshot" in snapshot.text
+    # A: 1000 income - 300 transferred out - 100 expense = 600
+    assert "600.00" in snapshot.text
+    # B: 300 transferred in = 300
+    assert "300.00" in snapshot.text
+
+
+def test_editing_live_transfer_after_close_does_not_change_the_snapshot(
+    client: TestClient,
+) -> None:
+    a = _create_channel(client, "Channel A")
+    b = _create_channel(client, "Channel B")
+    period_id = _create_payout_period(client, "15th", "1000", a)
+
+    # Created via crud directly rather than POST /transfers -- the transfer
+    # edge's HTML only renders data-edge-id once both channels are placed on
+    # the Cash Flow canvas, which is tangential to what this test covers.
+    db = TestingSessionLocal()
+    try:
+        transfer = crud.create_transfer(
+            db,
+            schemas.TransferCreate(
+                payout_period_id=int(period_id),
+                from_channel_id=int(a),
+                to_channel_id=int(b),
+                amount=300,
+            ),
+            TEST_USER_ID,
+        )
+        transfer_id = transfer.id
+    finally:
+        db.close()
+
+    closed = client.post(f"/payout-periods/{period_id}/cycles")
+    cycle_match = re.search(r"cycle_id=(\d+)", closed.text)
+    assert cycle_match is not None
+    cycle_id = cycle_match.group(1)
+
+    # Now edit the live transfer -- this is exactly the scenario #84 exists
+    # to fix: editing this cycle's transfer amount used to silently
+    # overwrite the only record that ever existed.
+    # 450, not e.g. 700 -- picked so it doesn't coincidentally match any
+    # other number in this test (1000 - 300 = 700 would collide with a
+    # naive "700" edit and make a real bug look like a pass).
+    client.patch(f"/transfers/{transfer_id}", data={"amount": "450"})
+
+    snapshot = client.get(f"/payout-periods/{period_id}/cycles", params={"cycle_id": cycle_id})
+    assert "-₱300.00" in snapshot.text  # snapshot still shows the old transfer amount
+    assert "₱700.00" in snapshot.text  # and the balance computed from it (1000 - 300)
+    assert "-₱450.00" not in snapshot.text
+    assert "₱550.00" not in snapshot.text
+
+    live = client.get(f"/payout-periods/{period_id}/cycles")
+    assert "-₱450.00" in live.text  # live view reflects the edit
+    assert "₱550.00" in live.text  # and the balance recomputed from it (1000 - 450)
+
+
+def test_cycle_history_requires_ownership(client: TestClient) -> None:
+    response = client.get("/payout-periods/999999/cycles")
+    assert response.status_code == 404
+
+
+def test_close_cycle_requires_ownership(client: TestClient) -> None:
+    response = client.post("/payout-periods/999999/cycles")
+    assert response.status_code == 404
+
+
+def test_viewing_unknown_cycle_id_404s(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", "1000", channel_id)
+
+    response = client.get(f"/payout-periods/{period_id}/cycles", params={"cycle_id": "999999"})
+    assert response.status_code == 404
+
+
+def test_history_link_appears_on_expenses_page(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", "1000", channel_id)
+
+    response = client.get("/expenses")
+    assert response.status_code == 200
+    assert f"/payout-periods/{period_id}/cycles" in response.text
+
+
+def test_multiple_closed_cycles_ordered_newest_first(client: TestClient) -> None:
+    channel_id = _create_channel(client, "BPI")
+    period_id = _create_payout_period(client, "15th", "1000", channel_id)
+
+    first = client.post(f"/payout-periods/{period_id}/cycles")
+    first_id = re.search(r"cycle_id=(\d+)", first.text)
+    assert first_id is not None
+
+    client.patch(
+        f"/payout-periods/{period_id}",
+        data={"income_amount": "2000", "receiving_channel_id": channel_id},
+    )
+    second = client.post(f"/payout-periods/{period_id}/cycles")
+    assert "2 closed" in second.text
+
+    # Newest cycle chip should appear before the older one in the rail.
+    second_id_match = re.search(r"cycle_id=(\d+)", second.text)
+    assert second_id_match is not None
+    second_id = second_id_match.group(1)
+    assert second.text.index(f"cycle_id={second_id}") < second.text.index(
+        f"cycle_id={first_id.group(1)}"
+    )


### PR DESCRIPTION
Closes #84.

Mockup posted on the issue (design pass per CLAUDE.md's UI-changes convention) and confirmed by @silvaej before this build: https://claude.ai/code/artifact/e4230aea-ba01-40ca-a791-c0785959ee76

**Key design decision, confirmed explicitly before writing any code**: snapshotting is explicit-action-only (a "Close this cycle" button), not auto-triggered on some inferred date — `PayoutPeriod` has no real calendar anchor (just a label like "15th"), so there's no clean way to know "a new cycle started" automatically without also inventing a calendar-date concept, which is a separate, bigger decision.

## What this does
- New `PayoutCycle` + `PayoutCycleBalance` tables (migration included). A cycle is a dated, locked snapshot of one payout period's `channel_balances()` at the moment it was closed — one balance row per channel that had any activity (income/transfers/expenses), each denormalizing the channel's name/color rather than FK'ing to `Channel` (a historical record shouldn't block deleting a channel used only in old history, or need updating if that channel is later renamed/recolored).
- `GET/POST /payout-periods/{id}/cycles` — a new "Cycle history" page: a rail of clickable chips (Live template + each closed cycle, newest first), and a balance table (Channel / Income / Transfers / Expenses / Net) for whichever is selected.
- Closing a cycle is **purely additive** — the live template (period, its transfers, its expenses) is completely untouched. No data-loss risk, no "did I already close this month" bookkeeping to get wrong.
- New History icon-button (clock icon) next to Edit/Delete on each payout period row on the Expenses page, linking to its cycle history.
- Two new CSS component classes (`.cycle-rail`, `.cycle-chip`) mirroring the existing `.preset-trigger` button-chip language rather than inventing a new visual style, plus a `badge_from_name()` macro for rendering a channel badge from just a name+color (snapshots don't retain logo/badge_label data) and an `icon_history()` macro.

## Verification
- Full test suite green (208 passed) — new `tests/test_payout_cycles.py` covers: live view with no cycles closed, closing a cycle and viewing its snapshot, **the core scenario #84 exists to fix** (editing a live transfer after closing does not change the already-closed snapshot, and the live view correctly reflects the edit), ownership checks, multi-cycle ordering.
- Visually verified in Chrome against the real compiled CSS (both the live-template view and a closed-snapshot view) — matches the mockup's direction.
- Along the way, caught and fixed a bug in my own test setup (not a product bug): a naive `_create_channel` test helper regex was returning the wrong channel ID once 2+ channels existed on a page — fixed to match the pattern already used correctly in `test_transfers.py`.