### PR TITLE
(fix) verify tailwindcss checksum with python3 instead of sha256sum -c

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.0.0/tailwindcss-linux-x64 && echo '09c1a5997d68f5e0127d9737593e7dc658fc96dc1851d782a78983d0d6a03c7c  tailwindcss' | sha256sum -c - && chmod +x tailwindcss && ./tailwindcss -i app/static/css/input.css -o app/static/css/style.css",
+  "buildCommand": "curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.0.0/tailwindcss-linux-x64 && python3 -c 'import hashlib,sys; sys.exit(0 if hashlib.sha256(open(\"tailwindcss\",\"rb\").read()).hexdigest()==\"09c1a5997d68f5e0127d9737593e7dc658fc96dc1851d782a78983d0d6a03c7c\" else 1)' && chmod +x tailwindcss && ./tailwindcss -i app/static/css/input.css -o app/static/css/style.css",
   "regions": ["sin1"],
   "git": {
     "deploymentEnabled": {


### PR DESCRIPTION
## Summary
- Every Vercel deployment has failed since PR #110 (#75's checksum-verification fix) — confirmed via the GitHub Deployments API: every deployment before that commit succeeded, every one since (including the fix commit itself) has failed. Clean bisection: only that one line changed between the last known-good deploy and the first failing one.
- Ruled out a wrong/stale pinned hash: re-downloaded the real `tailwindcss-linux-x64` v4.0.0 asset independently and its SHA-256 matches the pinned value exactly.
- Ruled out a shell-syntax bug: the exact `buildCommand` string runs successfully end-to-end locally (bash + GNU coreutils).
- Couldn't pull Vercel's actual build log (dashboard SSO-gated, no `vercel`/`node`/`npx` or stored credentials in this environment) to see the literal failing line, so the precise mechanism is a well-evidenced hypothesis, not a confirmed log-verified cause — see #126 for the full writeup.
- Leading hypothesis: `sha256sum -c -`'s GNU-coreutils-specific stdin (`-`) + two-space-format parsing doesn't behave the same (or isn't available at all) in Vercel's actual Python-builder build container.

## Fix
Replace the `sha256sum -c -` step with a `python3 -c` one-liner (`hashlib.sha256`, direct hex comparison, no `-c`/stdin format parsing). `python3` is guaranteed present in this build container regardless of coreutils flavor — it's literally what installs `requirements.txt` and runs the app for this project. Same fail-loudly-on-mismatch security property as #75, same pinned hash, zero dependency on which `sha256sum` implementation (or whether one) is on `PATH`.

## Test plan
- [x] `python -m json.tool vercel.json` — valid JSON
- [x] Extracted the literal `buildCommand` string from the parsed JSON and ran it end-to-end locally with a real Python interpreter standing in for `python3`: download succeeds, checksum check passes (verified it correctly fails on a deliberately wrong hash too), `chmod +x` succeeds. The only step that doesn't complete locally is executing the Linux ELF binary itself (`Exec format error`) — expected on this Windows dev machine, not applicable to Vercel's actual Linux build container.
- [x] `poetry run pytest` — 219 passed (unaffected, config-only change)
- [ ] Actual Vercel preview deployment on this PR — please check the Vercel check on this PR turns green; if it's still red, we'll need real build logs from the dashboard to see the literal error (not accessible from this environment)

Closes #126