### PR TITLE
(fix) move tailwindcss verify+build into a real script, out of vercel.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Downloads the standalone tailwindcss binary and compiles app/static/css/style.css.
+# Lives in its own file (rather than inline in vercel.json's buildCommand) so its
+# quoting/escaping is normal shell syntax, not a JSON string -- see issue #126:
+# every deployment failed after a checksum-verification step was first added
+# inline to buildCommand, and the leading suspect is Vercel wrapping buildCommand
+# in its own outer quoting that a `'...'`-containing one-liner could collide with.
+set -e
+
+curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.0.0/tailwindcss-linux-x64
+
+expected=09c1a5997d68f5e0127d9737593e7dc658fc96dc1851d782a78983d0d6a03c7c
+actual=$(sha256sum tailwindcss | cut -d " " -f1)
+if [ "$actual" != "$expected" ]; then
+  echo "tailwindcss checksum mismatch: expected $expected, got $actual" >&2
+  exit 1
+fi
+
+chmod +x tailwindcss
+./tailwindcss -i app/static/css/input.css -o app/static/css/style.css

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.0.0/tailwindcss-linux-x64 && python3 -c 'import hashlib,sys; sys.exit(0 if hashlib.sha256(open(\"tailwindcss\",\"rb\").read()).hexdigest()==\"09c1a5997d68f5e0127d9737593e7dc658fc96dc1851d782a78983d0d6a03c7c\" else 1)' && chmod +x tailwindcss && ./tailwindcss -i app/static/css/input.css -o app/static/css/style.css",
+  "buildCommand": "sh scripts/vercel-build.sh",
   "regions": ["sin1"],
   "git": {
     "deploymentEnabled": {


### PR DESCRIPTION
## Summary
Follow-up to #127, which did **not** fix the deployment failure — confirmed via a fresh `dev` deployment on that exact merge commit still failing identically (`npx vercel inspect dpl_224sm8jnWtqsQq1kGfURVzTj3Guw --logs`, still SSO-gated / no accessible logs from here).

New theory: both the original `sha256sum -c -` line and #127's `python3 -c '...'` replacement share something the pre-#75 `buildCommand` never had — **single quotes embedded directly in the JSON `buildCommand` string**. If Vercel wraps `buildCommand` in its own outer shell quoting when invoking it, an embedded `'...'` argument could terminate that wrapping early and corrupt the rest of the command. That would explain both attempts failing identically on Vercel despite each running correctly when executed directly, locally (outside Vercel's actual invocation wrapper, which still isn't observable from here).

## Fix
Move the whole download → verify → compile sequence into `scripts/vercel-build.sh`. `vercel.json`'s `buildCommand` becomes just `sh scripts/vercel-build.sh` — **zero quote characters** left in the JSON string, so nothing inside can collide with whatever Vercel's outer invocation does. Back to a plain `sha256sum <file> | cut -d" " -f1` comparison (no `-c`/stdin-format dependency either, portable across coreutils flavors) since script-file quoting is no longer a JSON-embedding concern.

Also added `.gitattributes` (`*.sh text eol=lf`) so this and any future shell scripts always commit/checkout with LF line endings regardless of a contributor's local `core.autocrlf` — CRLF in a shell script's shebang line breaks execution on Linux, which would be an easy way to reintroduce a silent failure here later.

## Test plan
- [x] `python -m json.tool vercel.json` — valid JSON, `buildCommand` is exactly `sh scripts/vercel-build.sh`
- [x] Ran `scripts/vercel-build.sh` directly end-to-end locally: download succeeds, checksum passes silently on the real binary, `chmod +x` succeeds (reaches the same "can't execute a Linux ELF on this Windows box" point as before, expected/not applicable to Vercel's actual Linux container)
- [x] Verified the mismatch path too: substituted a wrong hash into a scratch copy of the script and confirmed it prints `tailwindcss checksum mismatch: expected ..., got ...` and exits non-zero
- [x] Confirmed the committed blob has LF line endings, not CRLF (`git show :scripts/vercel-build.sh | cat -A`)
- [x] `poetry run ruff check .` / `poetry run pytest` — 219 passed (unaffected, no Python/template changes)
- [ ] Actual Vercel deployment on `dev` after merge — please confirm the `Vercel` check goes green this time; if it's still red, we're out of blind guesses and need real build logs from the dashboard (not accessible from this environment) to see the literal error line

Still tracks #126.