### PR TITLE
(fix) allow the OAuth provider origins in the CSP form-action directive

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.auth import SESSION_COOKIE_MAX_AGE_SECONDS, NotAuthenticated, get_curre
 from app.config import settings
 from app.csrf import csrf_protect
 from app.database import get_db
+from app.oauth import OAUTH_REDIRECT_ORIGINS
 from app.rate_limit import limiter
 from app.routers import (
     admin,
@@ -79,7 +80,13 @@ _CSP = (
     "connect-src 'self'; "
     "frame-ancestors 'none'; "
     "base-uri 'self'; "
-    "form-action 'self'"
+    # The OAuth provider origins are required here, not optional hardening
+    # slack: the login form submits to /auth/{provider}/start, which 302s to
+    # the provider, and Chrome checks form-action against every redirect hop
+    # -- omitting them blocks login outright (issue #129). Still restricts
+    # submissions to arbitrary third-party origins, which is the exfiltration
+    # path this directive exists to close.
+    "form-action 'self' " + " ".join(OAUTH_REDIRECT_ORIGINS)
 )
 
 

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -22,6 +22,24 @@ oauth.register(
     client_kwargs={"scope": "read:user user:email"},
 )
 
+# Origins /auth/{provider}/start 302s the browser to when a login begins.
+# These MUST appear in the CSP's form-action directive (app/main.py) or Chrome
+# blocks the entire login: it enforces form-action against every hop of a
+# redirect chain, not just the form's initial target (Firefox doesn't -- a
+# long-standing cross-browser difference), and login.html's provider buttons
+# submit a real <form> to /auth/{provider}/start, which then redirects here.
+# Chrome reports such a violation against the *original* same-origin form
+# target, not the redirect that actually tripped it, which makes it read like
+# 'self' is rejecting a same-origin URL. See issue #129.
+#
+# Keep in sync with the register() calls above when adding a provider.
+OAUTH_REDIRECT_ORIGINS = (
+    # google's authorization_endpoint, resolved via the OIDC discovery doc above
+    "https://accounts.google.com",
+    # github's authorize_url above
+    "https://github.com",
+)
+
 
 async def fetch_identity(
     provider: str, client: Any, token: dict[str, Any]

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,5 +1,10 @@
+from urllib.parse import urlparse
+
+import httpx
 import pytest
 from fastapi.testclient import TestClient
+
+from app.oauth import OAUTH_REDIRECT_ORIGINS
 
 
 def test_security_headers_present_on_every_response(client: TestClient) -> None:
@@ -10,6 +15,46 @@ def test_security_headers_present_on_every_response(client: TestClient) -> None:
     csp = response.headers["Content-Security-Policy"]
     assert "default-src 'self'" in csp
     assert "frame-ancestors 'none'" in csp
+
+
+def _form_action(response: httpx.Response) -> list[str]:
+    directive = next(
+        part
+        for part in response.headers["Content-Security-Policy"].split("; ")
+        if part.startswith("form-action ")
+    )
+    return directive.split()
+
+
+def test_csp_form_action_allows_the_github_redirect_target(client: TestClient) -> None:
+    """Regression test for #129: `form-action 'self'` alone broke login in
+    Chrome, which enforces form-action against every hop of a redirect chain
+    -- login.html submits a real <form> to /auth/{provider}/start, which 302s
+    to the provider's own origin.
+
+    Asserts against the redirect's *actual* Location header rather than a
+    hardcoded origin, so it fails if github's authorize_url moves without
+    form-action following it. GitHub only: its authorize_url is pinned in
+    app/oauth.py, so this stays offline. Google's comes from a live OIDC
+    discovery fetch, which would make this suite network-dependent -- covered
+    by the constant-based test below instead."""
+    response = client.get("/auth/github/start", follow_redirects=False)
+    assert response.status_code == 302
+
+    location = urlparse(response.headers["location"])
+    assert f"{location.scheme}://{location.netloc}" in _form_action(response)
+
+
+def test_csp_form_action_allows_every_declared_oauth_origin(client: TestClient) -> None:
+    """Guards the realistic drift case for #129: a provider gets added to
+    app/oauth.py's register() calls and OAUTH_REDIRECT_ORIGINS, but the CSP
+    isn't updated -- which breaks login in Chrome only, silently, with no
+    server-side error. Nothing else in the suite would catch that, since the
+    OAuth tests fake the provider exchange entirely (tests/conftest.py)."""
+    form_action = _form_action(client.get("/health"))
+    assert OAUTH_REDIRECT_ORIGINS, "expected at least one provider origin to be declared"
+    for origin in OAUTH_REDIRECT_ORIGINS:
+        assert origin in form_action
 
 
 def test_hsts_only_set_on_vercel(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes the OAuth login breakage reported on the `dev` deployment:

```
Sending form data to '.../auth/github/start?intent=login&keep_signed_in=on' violates the
following Content Security Policy directive: "form-action 'self'". The request has been blocked.
```

## Root cause

Regression from `aba8ea5` (PR #108 / issue #73), which added `form-action 'self'`.

**Chrome enforces `form-action` against every hop of a redirect chain, not just the form's initial target** (Firefox doesn't — a long-standing cross-browser difference, which is why this only reproduced in Chrome):

1. `login.html` / `signup_key_section.html` submit a real `<form method="get">` to `formaction="/auth/{provider}/start"` — same-origin, allowed by `'self'`.
2. `oauth_start` returns authlib's `authorize_redirect(...)` → **302 to the provider's origin**.
3. Chrome checks that hop against `form-action 'self'`, finds no match, blocks the whole submission.

Chrome then reports the violation against the *original same-origin* form target rather than the redirect that actually tripped it — which is what made the message look like `'self'` rejecting a same-origin URL.

Verified empirically, not assumed:

```
status:   302
Location: https://github.com/login/oauth/authorize?response_type=code&...
CSP:      ...; form-action 'self'
```

## Fix

`form-action 'self' https://accounts.google.com https://github.com`.

The origins are declared as `OAUTH_REDIRECT_ORIGINS` in `app/oauth.py`, right beside the `register()` calls, rather than inline in `main.py` — adding a provider then surfaces the CSP requirement at the point of the change. Without that, the failure mode is Chrome-only, silent, and produces no server-side error, so it's easy to ship broken.

This doesn't meaningfully weaken the directive: it still blocks submissions/redirects to arbitrary third-party origins, which is the exfiltration path `form-action` exists to close.

## Why nothing caught it

`tests/test_security_headers.py` only asserted on `default-src`/`frame-ancestors`, and the OAuth tests fake the provider exchange entirely (`tests/conftest.py`) — there's no browser anywhere in the suite, so no CSP enforcement.

## Test plan
- [x] Two new regression tests — one asserts github's **actual** 302 `Location` origin appears in `form-action`, the other that every declared origin does
- [x] **Verified both new tests fail against the old `form-action 'self'`** (temporarily reintroduced the bug to confirm they aren't vacuous), and pass after the fix
- [x] Kept the suite hermetic: an earlier draft parametrized the live-`Location` assertion over Google too, but that triggers a live OIDC discovery fetch — confirmed by running under a blackholed proxy, where it failed with `httpx.ConnectError`. Reworked so the whole file passes with **network blocked** (`HTTPS_PROXY=http://127.0.0.1:9`), matching this suite's no-external-calls property
- [x] `ruff check` / `ruff format --check` / `mypy app tests` / `djlint --check` all pass
- [x] `poetry run pytest` — 221 passed
- [ ] Confirm on the `dev` deployment that "Continue with GitHub"/"Continue with Google" now reach the provider

Closes #129