### PR TITLE
(feat) hint when a payout period's payday has passed but its cycle isn't closed

### DIFF
--- a/alembic/versions/6a478192fbe4_add_payout_period_payout_day.py
+++ b/alembic/versions/6a478192fbe4_add_payout_period_payout_day.py
@@ -1,0 +1,26 @@
+"""add payout period payout_day
+
+Revision ID: 6a478192fbe4
+Revises: 7a46ca981ef4
+Create Date: 2026-08-16 21:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '6a478192fbe4'
+down_revision: Union[str, None] = '7a46ca981ef4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Optional -- existing periods get NULL (no overdue hint until the user
+    # sets one). See models.py's PayoutPeriod.payout_day docstring.
+    op.add_column('payout_periods', sa.Column('payout_day', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('payout_periods', 'payout_day')

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,9 +1,10 @@
+import calendar
 import json
 import logging
 import math
 import secrets
 import zoneinfo
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal, NamedTuple
 
 from sqlalchemy import func, or_, select
@@ -508,6 +509,7 @@ def create_payout_period(
         label=data.label,
         income_amount=data.income_amount,
         receiving_channel_id=data.receiving_channel_id,
+        payout_day=data.payout_day,
         display_order=(max_order or 0) + 1,
         user_id=user_id,
     )
@@ -525,6 +527,7 @@ def update_payout_period(
     if period is not None:
         period.income_amount = data.income_amount
         period.receiving_channel_id = data.receiving_channel_id
+        period.payout_day = data.payout_day
         db.commit()
         db.refresh(period)
     return period
@@ -1498,6 +1501,58 @@ def channel_presets_by_group() -> dict[str, list[dict[str, str]]]:
     return groups
 
 
+def _most_recent_monthly_occurrence(day: int, today: date) -> date:
+    """The most recent calendar date <= today whose day-of-month is `day`,
+    clamped to the last day of a shorter month (e.g. day=31 in April -> 30)."""
+    year, month = today.year, today.month
+    clamped = min(day, calendar.monthrange(year, month)[1])
+    candidate = date(year, month, clamped)
+    if candidate <= today:
+        return candidate
+    month -= 1
+    if month == 0:
+        month, year = 12, year - 1
+    clamped = min(day, calendar.monthrange(year, month)[1])
+    return date(year, month, clamped)
+
+
+def overdue_payout_period_ids(
+    db: Session, user_id: int, payout_periods: list[models.PayoutPeriod]
+) -> set[int]:
+    """Periods whose payout_day has passed this month with no PayoutCycle
+    closed since -- a UI hint only (see #134), not enforcement. Closing a
+    cycle clears the hint until next month's payday passes again. Periods
+    with no payout_day set never show it -- that field is optional."""
+    candidates = [p for p in payout_periods if p.payout_day is not None]
+    if not candidates:
+        return set()
+
+    today = datetime.now(UTC).date()
+    # dict(Result.tuples()) is ambiguous -- Result exposes .keys(), which
+    # makes dict() try mapping-style construction (subscripting the Result
+    # itself) instead of treating it as an iterable of pairs. .all() first
+    # materializes a plain list of tuples, sidestepping that.
+    latest_closed_by_period: dict[int, datetime] = dict(
+        db.execute(
+            select(models.PayoutCycle.payout_period_id, func.max(models.PayoutCycle.closed_at))
+            .where(models.PayoutCycle.user_id == user_id)
+            .group_by(models.PayoutCycle.payout_period_id)
+        )
+        .tuples()
+        .all()
+    )
+
+    overdue = set()
+    for period in candidates:
+        assert period.payout_day is not None  # narrowed by the `candidates` filter above
+        occurrence = _most_recent_monthly_occurrence(period.payout_day, today)
+        latest_closed = latest_closed_by_period.get(period.id)
+        if latest_closed is not None and latest_closed.date() >= occurrence:
+            continue
+        overdue.add(period.id)
+    return overdue
+
+
 def expenses_page_data(db: Session, user_id: int, q: str | None = None) -> dict:
     channels = list_channels(db, user_id)
     payout_periods = list_payout_periods(db, user_id)
@@ -1527,6 +1582,7 @@ def expenses_page_data(db: Session, user_id: int, q: str | None = None) -> dict:
         "channel_types": CHANNEL_TYPES,
         "channel_preset_groups": channel_presets_by_group(),
         "payout_periods": payout_periods,
+        "overdue_payout_period_ids": overdue_payout_period_ids(db, user_id, payout_periods),
         "expenses": list_expenses(db, user_id, q),
         "q": q or "",
         "onboarding_step": onboarding_step,

--- a/app/models.py
+++ b/app/models.py
@@ -111,6 +111,12 @@ class PayoutPeriod(Base):
     receiving_channel_id: Mapped[int | None] = mapped_column(
         ForeignKey("channels.id"), nullable=True
     )
+    # Optional day-of-month this period's payday falls on -- same pattern as
+    # Expense.due_day. Purely a hint (crud.overdue_payout_period_ids uses it
+    # to flag periods whose payday has passed with no cycle closed since),
+    # not a real calendar anchor: `label` stays free text, and nothing else
+    # in the app infers dates from it. See issue #134.
+    payout_day: Mapped[int | None] = mapped_column(nullable=True)
 
     receiving_channel: Mapped[Channel | None] = relationship()
 

--- a/app/routers/payout_periods.py
+++ b/app/routers/payout_periods.py
@@ -20,12 +20,17 @@ def _parse_channel_id(raw: str) -> int | None:
     return int(raw) if raw else None
 
 
+def _parse_payout_day(raw: str) -> int | None:
+    return int(raw) if raw else None
+
+
 @router.post("")
 def create_payout_period(
     request: Request,
     label: str = Form(...),
     income_amount: float = Form(0),
     receiving_channel_id: str = Form(""),
+    payout_day: str = Form(""),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> HTMLResponse:
@@ -36,6 +41,7 @@ def create_payout_period(
                 label=label,
                 income_amount=income_amount,
                 receiving_channel_id=_parse_channel_id(receiving_channel_id),
+                payout_day=_parse_payout_day(payout_day),
             ),
             current_user.id,
         )
@@ -50,6 +56,7 @@ def update_payout_period(
     payout_period_id: int,
     income_amount: float = Form(...),
     receiving_channel_id: str = Form(""),
+    payout_day: str = Form(""),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ) -> HTMLResponse:
@@ -60,6 +67,7 @@ def update_payout_period(
             schemas.PayoutPeriodUpdate(
                 income_amount=income_amount,
                 receiving_channel_id=_parse_channel_id(receiving_channel_id),
+                payout_day=_parse_payout_day(payout_day),
             ),
             current_user.id,
         )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -28,11 +28,13 @@ class PayoutPeriodCreate(BaseModel):
     # configured yet.
     income_amount: float = Field(default=0, ge=0)
     receiving_channel_id: int | None = None
+    payout_day: int | None = Field(default=None, ge=1, le=31)
 
 
 class PayoutPeriodUpdate(BaseModel):
     income_amount: float = Field(ge=0)
     receiving_channel_id: int | None = None
+    payout_day: int | None = Field(default=None, ge=1, le=31)
 
 
 class ExpenseCreate(BaseModel):

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -274,6 +274,13 @@
     @apply bg-accent/10 text-accent border-accent;
   }
 
+  /* Hints that a payout period's payout_day has passed with no cycle closed
+     since -- see #134. Plain dot, not a .warn-pill: this is a nudge next to
+     an existing label, not a standalone status needing its own text. */
+  .overdue-dot {
+    @apply inline-block w-2 h-2 rounded-full bg-rust align-middle;
+  }
+
   .led {
     @apply w-full min-w-max table-fixed text-[13.5px] border-collapse;
   }

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -254,6 +254,7 @@
       <table class="led">
         <colgroup>
           <col class="w-24">
+          <col class="w-24">
           <col class="w-32">
           <col class="min-w-28">
           <col class="w-36">
@@ -261,6 +262,7 @@
         <thead>
           <tr>
             <th>Label</th>
+            <th class="text-right">Payout day</th>
             <th class="text-right">Income</th>
             <th class="text-right">Receiving channel</th>
             <th></th>
@@ -269,7 +271,26 @@
         <tbody>
           {% for period in payout_periods %}
             <tr>
-              <td data-label="Label">{{ period.label }}</td>
+              <td data-label="Label">
+                {{ period.label }}
+                {% if period.id in overdue_payout_period_ids %}
+                  <span class="overdue-dot"
+                        title="Payday ({{ period.payout_day }}) has passed — ready to close this cycle?"></span>
+                {% endif %}
+              </td>
+              <td class="num" data-label="Payout day">
+                <span class="view-payout-{{ period.id }}">{{ period.payout_day if period.payout_day else "—" }}</span>
+                <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
+                  <input class="field field-mono w-16"
+                         type="number"
+                         min="1"
+                         max="31"
+                         name="payout_day"
+                         form="edit-payout-form-{{ period.id }}"
+                         aria-label="Payout day"
+                         value="{{ period.payout_day or '' }}">
+                </div>
+              </td>
               <td class="num" data-label="Income">
                 <span class="view-payout-{{ period.id }}">{{ macros.peso(period.income_amount) }}</span>
                 <div class="edit-payout-{{ period.id }} hidden items-center justify-end gap-1">
@@ -339,10 +360,10 @@
               </td>
             </tr>
           {% else %}
-            {{ macros.empty_row(4, 'payout periods') }}
+            {{ macros.empty_row(5, 'payout periods') }}
           {% endfor %}
           <tr class="tr-add-btn">
-            <td colspan="4">
+            <td colspan="5">
               <button type="button"
                       id="add-payout-trigger"
                       class="add-btn w-20 justify-center disabled:bg-ink-soft disabled:cursor-not-allowed{{ ' hidden' if onboarding_step == 2 else '' }}"
@@ -361,6 +382,16 @@
                      placeholder="e.g. 15th"
                      aria-label="Label"
                      required>
+            </td>
+            <td class="num" data-label="Payout day">
+              <input class="field field-mono w-16"
+                     type="number"
+                     min="1"
+                     max="31"
+                     name="payout_day"
+                     form="add-payout-form"
+                     placeholder="Day"
+                     aria-label="Payout day">
             </td>
             <td class="num" data-label="Income">
               <div class="flex items-center justify-end gap-1">

--- a/tests/test_payout_periods.py
+++ b/tests/test_payout_periods.py
@@ -1,6 +1,9 @@
 import re
+from datetime import UTC, date, datetime
 
 from fastapi.testclient import TestClient
+
+from app.crud import _most_recent_monthly_occurrence
 
 
 def _create_channel(client: TestClient, name: str) -> str:
@@ -118,3 +121,120 @@ def test_delete_payout_period_in_use_by_expense_is_rejected(client: TestClient) 
     response = client.delete(f"/payout-periods/{period_id}")
     assert response.status_code == 409
     assert "still used" in response.json()["detail"]
+
+
+def test_create_payout_period_with_payout_day(client: TestClient) -> None:
+    response = client.post(
+        "/payout-periods",
+        data={
+            "label": "15th",
+            "income_amount": "1000",
+            "receiving_channel_id": "",
+            "payout_day": "15",
+        },
+    )
+    assert response.status_code == 200
+    assert re.search(r'name="payout_day"[^>]*value="15"', response.text)
+
+
+def test_update_payout_period_clears_payout_day(client: TestClient) -> None:
+    create = client.post(
+        "/payout-periods",
+        data={
+            "label": "15th",
+            "income_amount": "1000",
+            "receiving_channel_id": "",
+            "payout_day": "15",
+        },
+    )
+    match = re.search(r"/payout-periods/(\d+)", create.text)
+    assert match is not None
+    period_id = match.group(1)
+
+    response = client.patch(
+        f"/payout-periods/{period_id}",
+        data={"income_amount": "1000", "receiving_channel_id": "", "payout_day": ""},
+    )
+    assert response.status_code == 200
+    assert not re.search(r'name="payout_day"[^>]*value="\d', response.text)
+
+
+# --- Overdue-hint (payout_day) -----------------------------------------------
+# Regression coverage for #134. `_most_recent_monthly_occurrence` is tested
+# directly (pure function, no monkeypatching needed) for the calendar edge
+# cases; the router-level tests use `today.day` itself as the payout_day so
+# "is this overdue" is deterministic regardless of what day the suite runs on
+# -- `_most_recent_monthly_occurrence` always returns a date <= today by
+# construction, so payout_day == today.day always resolves to "occurred
+# today", which is exactly the boundary case worth covering anyway.
+
+
+def test_most_recent_monthly_occurrence_same_day() -> None:
+    assert _most_recent_monthly_occurrence(15, date(2026, 6, 15)) == date(2026, 6, 15)
+
+
+def test_most_recent_monthly_occurrence_earlier_this_month() -> None:
+    assert _most_recent_monthly_occurrence(5, date(2026, 6, 20)) == date(2026, 6, 5)
+
+
+def test_most_recent_monthly_occurrence_not_yet_this_month_falls_back_to_last_month() -> None:
+    assert _most_recent_monthly_occurrence(25, date(2026, 6, 5)) == date(2026, 5, 25)
+
+
+def test_most_recent_monthly_occurrence_clamps_to_shorter_month() -> None:
+    # February 2026 (not a leap year) has 28 days -- day 31 clamps to the 28th.
+    assert _most_recent_monthly_occurrence(31, date(2026, 2, 28)) == date(2026, 2, 28)
+    # Asking on March 5th, before March's own 31st has occurred, falls back
+    # to February's clamped occurrence, not March 31st.
+    assert _most_recent_monthly_occurrence(31, date(2026, 3, 5)) == date(2026, 2, 28)
+
+
+def test_most_recent_monthly_occurrence_wraps_year_boundary() -> None:
+    assert _most_recent_monthly_occurrence(31, date(2026, 1, 5)) == date(2025, 12, 31)
+
+
+def test_payout_period_with_no_payout_day_never_shows_overdue_dot(client: TestClient) -> None:
+    response = client.post(
+        "/payout-periods",
+        data={"label": "15th", "income_amount": "1000", "receiving_channel_id": ""},
+    )
+    assert response.status_code == 200
+    assert "overdue-dot" not in response.text
+
+
+def test_payout_period_shows_overdue_dot_once_payday_has_passed(client: TestClient) -> None:
+    today = datetime.now(UTC).date()
+    response = client.post(
+        "/payout-periods",
+        data={
+            "label": "Today's payday",
+            "income_amount": "1000",
+            "receiving_channel_id": "",
+            "payout_day": str(today.day),
+        },
+    )
+    assert response.status_code == 200
+    assert "overdue-dot" in response.text
+
+
+def test_closing_a_cycle_clears_the_overdue_dot(client: TestClient) -> None:
+    today = datetime.now(UTC).date()
+    create = client.post(
+        "/payout-periods",
+        data={
+            "label": "Today's payday",
+            "income_amount": "1000",
+            "receiving_channel_id": "",
+            "payout_day": str(today.day),
+        },
+    )
+    match = re.search(r"/payout-periods/(\d+)", create.text)
+    assert match is not None
+    period_id = match.group(1)
+    assert "overdue-dot" in create.text
+
+    close = client.post(f"/payout-periods/{period_id}/cycles")
+    assert close.status_code == 200
+
+    index = client.get("/expenses")
+    assert "overdue-dot" not in index.text


### PR DESCRIPTION
## Summary
- New optional `payout_day` (1-31) on `PayoutPeriod`, same pattern as `Expense.due_day` (#66) — additive migration, existing periods get `NULL`
- A small red dot appears next to a period's label once its most recent monthly occurrence of `payout_day` has passed with no `PayoutCycle` closed since; closing a cycle clears it until next month's payday passes again
- Periods with no `payout_day` set never show it — matches this app's usual "optional field just returns fewer results" pattern
- Small tweak to the existing Payout periods table on Expenses (new column + a dot), not a new page/surface — no mockup needed per CLAUDE.md's UI-change process

## Design decision
Discussed two ways to define "already over" before implementing (`PayoutPeriod.label` is free text like "15th", not a real calendar anchor — #84 deliberately avoided inferring dates from it):
1. **Chosen**: add `payout_day`, mirroring `Expense.due_day` — exact signal, small schema addition
2. Derive "over" from existing `Expense.due_day` values on the period's expenses — no schema change, but a period with no due-dated expenses would look "over" by default (false positive)

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 231 passed (10 new: 5 direct unit tests on the date-of-month math covering same-day/earlier-this-month/fallback-to-last-month/clamping-to-a-shorter-month/year-boundary-wrap, plus router-level tests for create/update persisting `payout_day`, no-`payout_day`-never-overdue, dot-appears-once-payday-passed, dot-clears-after-closing-a-cycle)
- [x] **Caught and fixed a real bug via the new tests**: `dict(Result.tuples())` is ambiguous in SQLAlchemy 2.0 — `Result` exposes `.keys()`, so `dict()` tries mapping-style construction (subscripting the `Result` itself) instead of treating it as pairs, raising `TypeError: 'ChunkedIteratorResult' object is not subscriptable`. Fixed with `.tuples().all()` to materialize a plain list first.
- [x] Rendered the real page (TestClient + local static-file preview, same trick used for #65/#84) in Chrome with three periods — overdue (payday today, unclosed), not-overdue (payday today, but already closed a cycle since), and no-`payout_day` — confirmed correct dot placement in the raw HTML. The dot itself didn't paint in that *local* preview only because this dev machine has no `tailwindcss` binary to rebuild `style.css` with the new `.overdue-dot` class (pre-existing local-environment limitation, not a code issue — `bg-rust` is an already-proven token used successfully elsewhere, e.g. `.warn-red`)

Closes #134