### PR TITLE
(feat) explain what the Overview/Assets summary cards mean

### DIFF
--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -6,7 +6,8 @@
       <div class="page-sub">What you own, at a glance</div>
     </div>
   </div>
-  <div class="card mb-5 max-w-xs">
+  <div class="card mb-5 max-w-xs"
+       title="Sum of everything below — doesn't include money sitting in your channels/accounts.">
     <div class="card-label">Total assets</div>
     <div class="card-value">{{ macros.peso(total_assets) }}</div>
   </div>

--- a/app/templates/partials/overview_page.html
+++ b/app/templates/partials/overview_page.html
@@ -7,15 +7,18 @@
     </div>
   </div>
   <div class="flex flex-wrap gap-4 mb-5">
-    <div class="card flex-1 min-w-[10rem]">
+    <div class="card flex-1 min-w-[10rem]"
+         title="Sum of everything on the Assets page — doesn't include money sitting in your channels/accounts.">
       <div class="card-label">Total assets</div>
       <div class="card-value">{{ macros.peso(total_assets) }}</div>
     </div>
-    <div class="card flex-1 min-w-[10rem]">
+    <div class="card flex-1 min-w-[10rem]"
+         title="Sum of what's currently used on your Credit lines — doesn't include Goals or upcoming Expenses.">
       <div class="card-label">Total liabilities</div>
       <div class="card-value">{{ macros.peso(total_liabilities) }}</div>
     </div>
-    <div class="card flex-1 min-w-[10rem]">
+    <div class="card flex-1 min-w-[10rem]"
+         title="Total assets minus total liabilities, as defined above.">
       <div class="card-label">Net worth</div>
       <div class="card-value {{ 'card-value-neg' if net_worth < 0 else '' }}">{{ macros.peso(net_worth) }}</div>
     </div>

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -58,3 +58,10 @@ def test_total_assets_kpi_reflects_sum(client: TestClient) -> None:
     response = client.get("/assets")
     assert response.status_code == 200
     assert "300.75" in response.text
+
+
+def test_total_assets_card_explains_what_it_means(client: TestClient) -> None:
+    """Regression test for #136 (same gap covered on Overview)."""
+    response = client.get("/assets")
+    assert response.status_code == 200
+    assert 'title="Sum of everything below' in response.text

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -224,3 +224,14 @@ def test_overview_surfaces_unfunded_channel_warning(client: TestClient) -> None:
 def test_unknown_section_still_404s(client: TestClient) -> None:
     response = client.get("/nonsense")
     assert response.status_code == 404
+
+
+def test_summary_cards_explain_what_they_mean(client: TestClient) -> None:
+    """Regression test for #136: the stat cards had no explanation of what
+    feeds them (e.g. "Total liabilities" only counts CreditLine.used, not
+    Goals or Expenses -- easy to assume otherwise)."""
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert 'title="Sum of everything on the Assets page' in response.text
+    assert "title=\"Sum of what's currently used on your Credit lines" in response.text
+    assert 'title="Total assets minus total liabilities' in response.text


### PR DESCRIPTION
## Summary
- Added a `title="..."` tooltip to Overview's three stat cards (Total assets / Total liabilities / Net worth) explaining exactly what each counts — reuses the same `title` pattern already on this page (cash-flow-warnings "See all warnings" link)
- Same gap on Assets page's own "Total assets" card, covered in the same pass per the issue

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 233 passed (2 new: tooltip text present on Overview's three cards, and on Assets' card)

Closes #136