### PR TITLE
(fix) stop nav icons jittering vertically while the rail collapses

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -137,6 +137,14 @@
        applyCollapsed() in base.html. Keeps label text from instantly
        reflowing/wrapping while the rail is still animating narrower. */
     @apply transition-opacity duration-150;
+    /* Without this, the label wraps onto a second line once the row's
+       shrinking width (mid-.rail-width-transition) drops below the text's
+       natural width -- .rail stacks tabs in a column, so that one row
+       growing taller pushes every row below it down, then snaps back up
+       150ms later once display:none removes the wrapped text from layout.
+       Reads as the whole nav jittering vertically during collapse/expand.
+       See issue #140. */
+    @apply whitespace-nowrap overflow-hidden;
   }
 
   /* Bottom tab bar -- the mobile replacement for .rail. Hidden by default;


### PR DESCRIPTION
## Summary
`.tab-label` had no `whitespace-nowrap`, so once the rail's shrinking width (mid the 200ms collapse/expand transition) dropped below the label text's natural width, it wrapped onto a second line. `.rail` stacks tabs in a flex column, so that one row growing taller pushed every row below it down, then snapped back up ~150ms later once `applyCollapsed()` set `display:none` on the label — reads as the whole nav jittering vertically during the animation.

## Fix
Add `whitespace-nowrap overflow-hidden` to `.tab-label` so it clips instead of wrapping while the row is still transitioning — keeps every `.tab` row's height constant through the whole animation.

## Test plan
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 233 passed (unaffected, pure CSS change, no existing test covers rail-collapse animation)
- [ ] Visual confirmation on the actual `dev` deployment that the rail collapse/expand no longer jitters — couldn't verify locally since this dev machine has no `tailwindcss` binary to rebuild `style.css` with the change (same pre-existing local-environment limitation noted on recent PRs); the utility classes themselves (`whitespace-nowrap`, `overflow-hidden`) are standard, unambiguous Tailwind core utilities

Closes #140