### PR TITLE
(fix) drop paid expenses from Overview's Upcoming section

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1475,7 +1475,11 @@ def overview_page_data(db: Session, user_id: int) -> dict:
     period = next_payout_period(db, user_id)
     upcoming_expenses = (
         sorted(
-            (e for e in list_expenses(db, user_id) if e.payout_period_id == period.id and e.active),
+            (
+                e
+                for e in list_expenses(db, user_id)
+                if e.payout_period_id == period.id and e.active and not e.paid
+            ),
             key=lambda e: (e.due_day is None, e.due_day),
         )
         if period is not None

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -226,6 +226,37 @@ def test_unknown_section_still_404s(client: TestClient) -> None:
     assert response.status_code == 404
 
 
+def test_paid_expenses_drop_off_the_upcoming_list(client: TestClient) -> None:
+    """Regression test for #137: marking an expense paid (#85) didn't remove
+    it from Overview's "Upcoming" section or its total, defeating the point
+    of marking it paid -- "upcoming" should mean "still owed"."""
+    channel_id = _create_channel(client, "Payroll")
+    period_id = _create_payout_period(client, "15th", "32000", channel_id)
+
+    create = client.post(
+        "/expenses",
+        data={
+            "name": "Meralco",
+            "amount": "2500.50",
+            "payout_period_id": period_id,
+            "channel_id": channel_id,
+        },
+    )
+    match = re.search(r"/expenses/(\d+)/paid", create.text)
+    assert match is not None
+    expense_id = match.group(1)
+
+    response = client.get("/overview")
+    assert "Meralco" in response.text
+
+    client.patch(f"/expenses/{expense_id}/paid", data={"paid": "true"})
+
+    response = client.get("/overview")
+    assert response.status_code == 200
+    assert "Meralco" not in response.text
+    assert "expenses due this period" in response.text  # empty-state row, no expenses left unpaid
+
+
 def test_summary_cards_explain_what_they_mean(client: TestClient) -> None:
     """Regression test for #136: the stat cards had no explanation of what
     feeds them (e.g. "Total liabilities" only counts CreditLine.used, not


### PR DESCRIPTION
## Summary
`overview_page_data`'s `upcoming_expenses` filter checked `payout_period_id` and `active` but not `paid` -- once a user checked an expense off as paid (#85), it kept showing in Overview's "Upcoming" section and kept counting toward `upcoming_expenses_total`, defeating the point of marking it paid.

## Fix
Add `and not e.paid` alongside the existing `e.active` check.

## Test plan
- [x] New test: creates an expense, confirms it shows in Upcoming, marks it paid via `PATCH /expenses/{id}/paid`, confirms it drops off the list (and the section falls back to its normal empty-state row, since the period itself still exists)
- [x] **Verified the test isn't vacuous**: temporarily reverted the filter to the old (buggy) version and confirmed the test fails against it, then restored the fix and confirmed it passes
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run pytest` — 234 passed

Closes #137