### PR TITLE
(fix) htmx-boost the cycle history link instead of a full page reload

### DIFF
--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -331,7 +331,11 @@
                   <a class="icon-btn"
                      title="Cycle history"
                      aria-label="Cycle history"
-                     href="/payout-periods/{{ period.id }}/cycles">{{ macros.icon_history() }}</a>
+                     href="/payout-periods/{{ period.id }}/cycles"
+                     hx-boost="true"
+                     hx-target="#page-content"
+                     hx-swap="innerHTML"
+                     hx-push-url="true">{{ macros.icon_history() }}</a>
                   <button type="button"
                           class="icon-btn hover:bg-accent/15 hover:text-accent"
                           title="Edit"

--- a/tests/test_payout_periods.py
+++ b/tests/test_payout_periods.py
@@ -238,3 +238,26 @@ def test_closing_a_cycle_clears_the_overdue_dot(client: TestClient) -> None:
 
     index = client.get("/expenses")
     assert "overdue-dot" not in index.text
+
+
+def test_cycle_history_link_is_htmx_boosted(client: TestClient) -> None:
+    """Regression test for #135: the link fell through to a full browser
+    navigation instead of an htmx swap, since #page-content itself isn't
+    boosted (only #rail/#tabbar/#more-sheet-overlay are) -- see
+    app/templates/base.html."""
+    create = client.post(
+        "/payout-periods",
+        data={"label": "15th", "income_amount": "1000", "receiving_channel_id": ""},
+    )
+    match = re.search(r"/payout-periods/(\d+)", create.text)
+    assert match is not None
+    period_id = match.group(1)
+
+    href = f'href="/payout-periods/{period_id}/cycles"'
+    assert href in create.text
+    link_tag = re.search(rf"<a[^>]*{re.escape(href)}[^>]*>", create.text, re.DOTALL)
+    assert link_tag is not None
+    assert 'hx-boost="true"' in link_tag.group()
+    assert 'hx-target="#page-content"' in link_tag.group()
+    assert 'hx-swap="innerHTML"' in link_tag.group()
+    assert 'hx-push-url="true"' in link_tag.group()


### PR DESCRIPTION
## Summary
`hx-boost` in this app is applied per-container (`#rail`, `#tabbar`, `#more-sheet-overlay`), not globally on `<body>` -- `#page-content` itself, where page-body content like `expenses_page.html` renders, has no boost. The "Cycle history" link on a payout period was a plain `<a href>` inside that unboosted content, so clicking it fell through to a normal browser navigation (a real, working, but full page reload) instead of the usual in-place htmx swap the rest of the app uses.

## Fix
Add the same `hx-boost="true" hx-target="#page-content" hx-swap="innerHTML" hx-push-url="true"` attributes the other boosted containers already use. `app/routers/payout_cycles.py`'s `index` route already branches correctly on `HX-Request` and returns `partials/payout_cycle_history_page.html` vs. the full `payout_cycle_history.html`, so this is purely the missing attributes on the link, no backend change.

## Test plan
- [x] New test asserts the link's `<a>` tag carries all four `hx-*` attributes
- [x] **Verified the test isn't vacuous**: temporarily reverted the template change and confirmed the test fails against it, then restored the fix and confirmed it passes
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` — 235 passed

Closes #135