### PR TITLE
(feat) rebrand app to "Vantage"

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ from app.routers import (
 )
 from app.templating import templates
 
-app = FastAPI(title="Finance Tracker", dependencies=[Depends(csrf_protect)])
+app = FastAPI(title="Vantage", dependencies=[Depends(csrf_protect)])
 app.state.limiter = limiter
 app.add_middleware(SlowAPIMiddleware)
 

--- a/app/manage_users.py
+++ b/app/manage_users.py
@@ -55,7 +55,7 @@ def create_key(max_uses: int, expires_days: int | None) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Manage finance-tracker user accounts.")
+    parser = argparse.ArgumentParser(description="Manage Vantage user accounts.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     create_parser = subparsers.add_parser(

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -117,10 +117,32 @@
     @apply flex items-center justify-between px-5 pb-4 mb-3 border-b border-line;
   }
   .rail-brand {
-    @apply flex items-center gap-2.5 min-w-0 transition-opacity duration-150;
+    @apply flex flex-col gap-1 min-w-0 transition-opacity duration-150;
   }
   .rail-greeting {
     @apply font-serif font-semibold text-sm text-ink truncate;
+  }
+
+  /* Wordmark -- see issue #131. Reused as-is (just a different `size`) in
+     the rail nav and on login/signup, so it lives as one macro
+     (macros.html's brand_wordmark) rather than being duplicated per
+     template. Accent-colored rather than plain ink: it's the one existing
+     brand color already used for active tabs/links, so the wordmark reads
+     as the same identity instead of introducing a second brand color. */
+  .brand-wordmark {
+    @apply inline-flex items-start font-serif font-extrabold tracking-tight text-accent leading-none;
+  }
+  .brand-wordmark-md {
+    @apply text-base;
+  }
+  .brand-wordmark-lg {
+    @apply text-xl;
+  }
+  .brand-wordmark-beta {
+    /* True superscript position/register (mono face, tracked-out caps) --
+       deliberately not a filled pill, reads as a trademark-style tag next
+       to the mark rather than a promotional badge. */
+    @apply font-mono text-[9px] font-bold uppercase tracking-wider text-ink-soft ml-1 relative -top-0.5;
   }
   .tab {
     @apply flex items-center gap-2.5 text-sm font-medium text-ink-soft px-5 py-2.5 border-l-[3px] border-transparent hover:bg-paper-dim hover:text-ink transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
     <meta name="currency-symbol" content="{{ currency_symbol }}">
-    <title>Finance Tracker</title>
+    <title>Vantage</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
           rel="stylesheet">
@@ -23,6 +23,7 @@
            hx-push-url="true">
         <div class="rail-head" id="rail-head">
           <div class="rail-brand" id="rail-brand">
+            {{ macros.brand_wordmark() }}
             {% set greeting_name = current_user.display_name if current_user and current_user.display_name else (current_user.email.split('@')[0] if current_user else '') %}
             <span class="rail-greeting" title="What's up, {{ greeting_name }}!">What's up, {{ greeting_name }}!</span>
           </div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
-    <title>Log in — Finance Tracker</title>
+    <title>Log in — Vantage</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
           rel="stylesheet">
@@ -18,6 +18,7 @@
           {% include "partials/auth_visual.html" %}
         {% endwith %}
         <div class="auth-form-pane">
+          {{ macros.brand_wordmark("lg") }}
           <div>
             <div class="page-title">Log in</div>
             <div class="page-sub">Welcome back — pick up where you left off.</div>

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -144,6 +144,12 @@
     <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
   </svg>
 {% endmacro %}
+{% macro brand_wordmark(size='md') %}
+  {# "beta" reads as a version marker (like a trademark tag), not a promotional
+     badge -- deliberately plain superscript text in the mono face rather than
+     a filled pill. See issue #131. #}
+  <div class="brand-wordmark brand-wordmark-{{ size }}">Vantage<span class="brand-wordmark-beta">beta</span></div>
+{% endmacro %}
 {% macro icon_google() %}
   <svg class="w-[18px] h-[18px]" viewBox="0 0 18 18">
     <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84c-.21 1.13-.85 2.09-1.81 2.73v2.27h2.92c1.71-1.57 2.69-3.89 2.69-6.64z" />

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
-    <title>Create account — Finance Tracker</title>
+    <title>Create account — Vantage</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
           rel="stylesheet">
@@ -12,12 +12,14 @@
     <script src="https://unpkg.com/htmx.org@2.0.2"></script>
   </head>
   <body class="font-sans text-ink bg-paper">
+    {% import "macros.html" as macros %}
     <div class="min-h-screen flex items-center justify-center p-4">
       <div class="auth-shell">
         {% with tagline = "You're setting up a new ledger — channels, payouts and bills, wired together." %}
           {% include "partials/auth_visual.html" %}
         {% endwith %}
         <div class="auth-form-pane">
+          {{ macros.brand_wordmark("lg") }}
           <div>
             <div class="page-title">Create your account</div>
             <div class="page-sub">Access is invite-only. Ask whoever runs this ledger for a key.</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "finance-tracker"
+name = "vantage"
 version = "0.2.0-beta"
-description = "Personal finance tracker (FastAPI + HTMX + Postgres)"
+description = "Vantage — personal finance tracker (FastAPI + HTMX + Postgres)"
 requires-python = ">=3.12,<4.0"
 dependencies = [
     "fastapi (==0.115.0)",


### PR DESCRIPTION
## Summary
Direction confirmed on the mockup: https://claude.ai/code/artifact/b8c76b71-5848-4992-b348-17b3f534fd3c

- Wordmark: "Vantage" in the app's existing accent blue, "beta" as an IBM Plex Mono superscript tag (not a filled badge) -- lives as one macro (`macros.brand_wordmark(size)`), reused in the rail nav (`size='md'`) and on login/signup (`size='lg'`)
- Rail nav: wordmark now sits above the existing personalized greeting inside `#rail-brand` (switched from a single row to a column stack); both still fade together on collapse exactly as before, no JS changes needed
- Login/signup: wordmark sits above the page title in `.auth-form-pane` -- the first brand touchpoint either page had at all. `signup.html` didn't import `macros.html` before this; added it
- Swept every `<title>` tag (`base.html`, `login.html`, `signup.html`), FastAPI's own app title in `main.py`, `pyproject.toml`'s `name`/`description`, and `manage_users.py`'s `--help` description
- Left `app/config.py`'s `database_url` default alone -- that's the Postgres DB name (`finance_tracker`, matching `docker-compose.yml`), infrastructure naming, not app branding

Deliberately out of scope, left to #132: an icon-only/monogram mark for the collapsed (icon-only) rail state, and the actual favicon file -- #132 builds on whatever lands here rather than shipping a placeholder that gets thrown away.

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` -- 235 passed
- [x] Confirmed `requirements.txt` doesn't need regenerating (`poetry export` output is byte-identical -- only `name`/`description` changed, not dependencies)
- [x] Verified the rendered markup directly (wordmark + "beta" span present, correct `size` variant, `<title>` tags updated) since this dev machine has no `tailwindcss` binary to rebuild `style.css` with the new `.brand-wordmark` classes locally (same pre-existing local-environment limitation noted on recent PRs) -- the CSS itself is standard Tailwind utilities plus one small `@apply` block, no exotic syntax
- Note: renaming `pyproject.toml`'s `name` field made Poetry create a brand-new local venv (keyed by project name), which surfaced an unrelated, pre-existing local-only gap -- `zoneinfo` has no timezone data on this Windows box without the `tzdata` PyPI package, which isn't a direct dependency here. Confirmed this is **not a regression**: it doesn't reproduce on Linux (real CI/Docker/Vercel all have system tzdata), and installing `tzdata` locally (not committed, just to unblock my own verification) made the full suite pass clean. Not fixing it here since it's unrelated to this rebrand -- happy to file a follow-up issue if useful for other Windows contributors.

Closes #131