### PR TITLE
(feat) add first-visit onboarding nudges to Cash Flow, Goals, Credit, Assets

### DIFF
--- a/alembic/versions/9c3f0e5a1b7d_add_onboarding_nudges.py
+++ b/alembic/versions/9c3f0e5a1b7d_add_onboarding_nudges.py
@@ -1,0 +1,35 @@
+"""add onboarding nudges
+
+Revision ID: 9c3f0e5a1b7d
+Revises: 6a478192fbe4
+Create Date: 2026-08-18 09:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '9c3f0e5a1b7d'
+down_revision: Union[str, None] = '6a478192fbe4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'onboarding_nudges',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('section', sa.String(length=20), nullable=False),
+        sa.Column(
+            'dismissed_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'section'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('onboarding_nudges')

--- a/app/crud.py
+++ b/app/crud.py
@@ -289,6 +289,39 @@ def needs_onboarding(db: Session, user: models.User) -> bool:
     return not _has_any_expenses(db, user.id)
 
 
+def _has_any_transfers(db: Session, user_id: int) -> bool:
+    stmt = select(models.Transfer.id).where(models.Transfer.user_id == user_id).limit(1)
+    return db.scalar(stmt) is not None
+
+
+def needs_nudge(db: Session, user_id: int, section: str, is_empty: bool) -> bool:
+    """Whether the first-visit nudge banner for `section` (one of "cashflow",
+    "goals", "credit", "assets" -- see issue #138) should show. Only while
+    the section is still empty *and* hasn't been explicitly dismissed --
+    auto-clears the moment either flips, same "auto-completes on real data"
+    spirit as the Channels/PayoutPeriods/Expenses flow above, just
+    per-section instead of a single global timestamp."""
+    if not is_empty:
+        return False
+    stmt = (
+        select(models.OnboardingNudge.id)
+        .where(models.OnboardingNudge.user_id == user_id, models.OnboardingNudge.section == section)
+        .limit(1)
+    )
+    return db.scalar(stmt) is None
+
+
+def dismiss_nudge(db: Session, user_id: int, section: str) -> None:
+    existing = db.scalar(
+        select(models.OnboardingNudge).where(
+            models.OnboardingNudge.user_id == user_id, models.OnboardingNudge.section == section
+        )
+    )
+    if existing is None:
+        db.add(models.OnboardingNudge(user_id=user_id, section=section))
+        db.commit()
+
+
 def skip_onboarding(db: Session, user: models.User) -> None:
     user.onboarding_completed_at = datetime.now(UTC)
     db.commit()
@@ -1275,6 +1308,7 @@ def assets_page_data(db: Session, user_id: int) -> dict:
         "assets": assets,
         "total_assets": sum(float(a.amount) for a in assets),
         "channels": list_channels(db, user_id),
+        "show_nudge": needs_nudge(db, user_id, "assets", is_empty=not assets),
     }
 
 
@@ -1396,6 +1430,7 @@ def goals_page_data(db: Session, user_id: int) -> dict:
             for g in goals
         ],
         "channels": list_channels(db, user_id),
+        "show_nudge": needs_nudge(db, user_id, "goals", is_empty=not goals),
     }
 
 
@@ -1452,6 +1487,7 @@ def credit_page_data(db: Session, user_id: int) -> dict:
     return {
         "credit_lines": [{"line": c, **credit_utilization(c)} for c in lines],
         "channels": list_channels(db, user_id),
+        "show_nudge": needs_nudge(db, user_id, "credit", is_empty=not lines),
     }
 
 
@@ -1750,6 +1786,13 @@ def cashflow_page_data(db: Session, user_id: int) -> dict:
         "channels": channels,
         "goals": goal_entries,
         "payout_data": payout_data,
+        # Page-level, not per-period -- Cash Flow shows one section per
+        # payout period, but the nudge is about the section/feature itself
+        # (Transfers), so "empty" means no transfers anywhere yet, not
+        # "this one period has none".
+        "show_nudge": needs_nudge(
+            db, user_id, "cashflow", is_empty=not _has_any_transfers(db, user_id)
+        ),
     }
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -301,3 +301,26 @@ class PayoutCycleBalance(Base):
     net: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
 
     payout_cycle: Mapped[PayoutCycle] = relationship()
+
+
+class OnboardingNudge(Base):
+    """Per-(user, section) dismissal for the first-visit nudge banners on
+    Cash Flow/Goals/Credit/Assets -- see issue #138. Distinct from
+    User.onboarding_completed_at (the Channels/PayoutPeriods/Expenses
+    3-step flow, which this doesn't touch): those three are genuinely
+    sequential, these four are independent, so each section is tracked
+    separately rather than folded into the same single timestamp. A row's
+    mere existence means "dismissed" -- crud.needs_nudge() also checks
+    whether the section still has no data, so the banner auto-clears the
+    moment either the user dismisses it or adds something, without
+    needing to distinguish the two."""
+
+    __tablename__ = "onboarding_nudges"
+    __table_args__ = (UniqueConstraint("user_id", "section"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    section: Mapped[str] = mapped_column(String(20), nullable=False)
+    dismissed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )

--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -81,3 +81,13 @@ def delete_asset(
 ) -> HTMLResponse:
     crud.delete_asset(db, asset_id, current_user.id)
     return _render_page(request, db, current_user.id)
+
+
+@router.post("/nudge/dismiss")
+def dismiss_nudge(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    crud.dismiss_nudge(db, current_user.id, "assets")
+    return _render_page(request, db, current_user.id)

--- a/app/routers/cashflow.py
+++ b/app/routers/cashflow.py
@@ -10,6 +10,12 @@ from app.templating import templates
 router = APIRouter(prefix="/cashflow", tags=["cashflow"])
 
 
+def _render_page(request: Request, db: Session, user_id: int) -> HTMLResponse:
+    return templates.TemplateResponse(
+        request, "partials/cashflow_page.html", crud.cashflow_page_data(db, user_id)
+    )
+
+
 @router.get("")
 def index(
     request: Request,
@@ -22,6 +28,16 @@ def index(
     return templates.TemplateResponse(
         request, template, crud.cashflow_page_data(db, current_user.id)
     )
+
+
+@router.post("/nudge/dismiss")
+def dismiss_nudge(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    crud.dismiss_nudge(db, current_user.id, "cashflow")
+    return _render_page(request, db, current_user.id)
 
 
 @router.post("/{payout_period_id}/save")

--- a/app/routers/credit.py
+++ b/app/routers/credit.py
@@ -87,3 +87,13 @@ def delete_credit_line(
 ) -> HTMLResponse:
     crud.delete_credit_line(db, credit_line_id, current_user.id)
     return _render_page(request, db, current_user.id)
+
+
+@router.post("/nudge/dismiss")
+def dismiss_nudge(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    crud.dismiss_nudge(db, current_user.id, "credit")
+    return _render_page(request, db, current_user.id)

--- a/app/routers/goals.py
+++ b/app/routers/goals.py
@@ -141,3 +141,13 @@ def delete_goal(
 ) -> HTMLResponse:
     crud.delete_goal(db, goal_id, current_user.id)
     return _render_page(request, db, current_user.id)
+
+
+@router.post("/nudge/dismiss")
+def dismiss_nudge(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> HTMLResponse:
+    crud.dismiss_nudge(db, current_user.id, "goals")
+    return _render_page(request, db, current_user.id)

--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -291,6 +291,29 @@
     @apply bg-gold-soft text-gold;
   }
 
+  /* First-visit nudge banners on Cash Flow/Goals/Credit/Assets -- see
+     issue #138. Same accent-tinted language as .onboard-banner above,
+     simplified: no progress bar (nothing sequential across these four
+     independent sections), no "Step X of Y" label. */
+  .nudge-banner {
+    @apply flex items-start gap-3.5 bg-accent/10 border border-accent/20 rounded-lg px-4 py-3 mb-5;
+  }
+  .nudge-icon {
+    @apply w-6 h-6 rounded-md bg-accent text-white flex items-center justify-center shrink-0;
+  }
+  .nudge-icon svg {
+    @apply w-3.5 h-3.5;
+  }
+  .nudge-copy {
+    @apply flex-1 text-sm text-ink;
+  }
+  .nudge-copy strong {
+    @apply block text-[10.5px] font-bold uppercase tracking-wide text-accent mb-0.5;
+  }
+  .nudge-dismiss {
+    @apply bg-transparent border-0 text-ink-soft text-xs font-semibold cursor-pointer whitespace-nowrap self-center hover:text-ink hover:underline;
+  }
+
   /* Payout cycle history's clickable timeline of "Live template" + each
      closed cycle -- see #84. Mirrors .preset-trigger's button-chip
      language rather than introducing a new visual style. */

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -50,6 +50,32 @@
 {% macro empty_state(label) %}
   <div class="text-center text-ink-soft text-sm py-6">No {{ label }} yet</div>
 {% endmacro %}
+{% macro nudge_banner(show, dismiss_url, target, title, copy) %}
+  {# First-visit nudge for Cash Flow/Goals/Credit/Assets -- see issue #138.
+     Independent per section (unlike the sequential 3-step Expenses banner),
+     so this is called once per page with that page's own dismiss route. #}
+  {% if show %}
+    <div class="nudge-banner">
+      <div class="nudge-icon">
+        <svg viewBox="0 0 24 24"
+             fill="none"
+             stroke="currentColor"
+             stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
+        </svg>
+      </div>
+      <div class="nudge-copy">
+        <strong>{{ title }}</strong>
+        {{ copy }}
+      </div>
+      <button type="button"
+              class="nudge-dismiss"
+              hx-post="{{ dismiss_url }}"
+              hx-target="{{ target }}"
+              hx-swap="outerHTML">Got it</button>
+    </div>
+  {% endif %}
+{% endmacro %}
 {% macro peso(amount) -%}
   {{- '-' if amount < 0 else '' }}{{ currency_symbol }}{{ "{:,.2f}".format(amount|abs) }}
 {%- endmacro %}

--- a/app/templates/partials/assets_page.html
+++ b/app/templates/partials/assets_page.html
@@ -6,6 +6,7 @@
       <div class="page-sub">What you own, at a glance</div>
     </div>
   </div>
+  {{ macros.nudge_banner(show_nudge, "/assets/nudge/dismiss", "#assets-page", "See your real net worth", "Track what you own outside your day-to-day channels — savings, investments, property — and Overview's net worth figure follows automatically.") }}
   <div class="card mb-5 max-w-xs"
        title="Sum of everything below — doesn't include money sitting in your channels/accounts.">
     <div class="card-label">Total assets</div>

--- a/app/templates/partials/cashflow_page.html
+++ b/app/templates/partials/cashflow_page.html
@@ -8,6 +8,7 @@
       </div>
     </div>
   </div>
+  {{ macros.nudge_banner(show_nudge, "/cashflow/nudge/dismiss", "#cashflow-page", "Route your money onward", "Income lands in one channel first — add a Transfer to move it from there to wherever it actually needs to end up, like a savings account or the wallet you pay bills from.") }}
   {% for data in payout_data %}
     <div class="section">
       <div class="section-title">{{ data.period.label }} cash flow</div>

--- a/app/templates/partials/credit_page.html
+++ b/app/templates/partials/credit_page.html
@@ -6,6 +6,7 @@
       <div class="page-sub">Credit lines and how close they are to their limit</div>
     </div>
   </div>
+  {{ macros.nudge_banner(show_nudge, "/credit/nudge/dismiss", "#credit-page", "Keep an eye on utilization", "Add a credit card or line here to see how close it is to its limit at a glance.") }}
   <div class="section">
     <div class="section-title">Credit lines<span class="pill">{{ credit_lines|length }} total</span></div>
     <form id="add-credit-form"

--- a/app/templates/partials/goals_page.html
+++ b/app/templates/partials/goals_page.html
@@ -6,6 +6,7 @@
       <div class="page-sub">Savings targets and the pace to hit them</div>
     </div>
   </div>
+  {{ macros.nudge_banner(show_nudge, "/goals/nudge/dismiss", "#goals-page", "Save toward something specific", "Set a target and fund it a little each payout — Goals track progress separately from your regular channel balances.") }}
   <div class="section">
     <div class="section-title">Goals<span class="pill">{{ goals|length }} total</span></div>
     <form id="add-goal-form"

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -65,3 +65,29 @@ def test_total_assets_card_explains_what_it_means(client: TestClient) -> None:
     response = client.get("/assets")
     assert response.status_code == 200
     assert 'title="Sum of everything below' in response.text
+
+
+# --- Onboarding nudge (#138) --------------------------------------------------
+
+
+def test_shows_nudge_when_no_assets_yet(client: TestClient) -> None:
+    response = client.get("/assets")
+    assert response.status_code == 200
+    assert "nudge-banner" in response.text
+    assert "See your real net worth" in response.text
+
+
+def test_nudge_disappears_once_an_asset_exists(client: TestClient) -> None:
+    response = client.post("/assets", data={"name": "BPI IMI", "amount": "100"})
+    assert "nudge-banner" not in response.text
+
+
+def test_dismissing_nudge_clears_it_even_while_still_empty(client: TestClient) -> None:
+    response = client.post("/assets/nudge/dismiss")
+    assert response.status_code == 200
+    assert "nudge-banner" not in response.text
+
+    # Stays dismissed on a fresh page load, not just the response to the
+    # dismiss request itself.
+    response = client.get("/assets")
+    assert "nudge-banner" not in response.text

--- a/tests/test_cashflow.py
+++ b/tests/test_cashflow.py
@@ -128,3 +128,39 @@ def test_fully_funded_goal_has_no_warning(client: TestClient) -> None:
     response = client.get("/cashflow")
     assert response.status_code == 200
     assert "isn't fully funded" not in response.text
+
+
+# --- Onboarding nudge (#138) --------------------------------------------------
+
+
+def test_shows_nudge_when_no_transfers_yet(client: TestClient) -> None:
+    response = client.get("/cashflow")
+    assert response.status_code == 200
+    assert "nudge-banner" in response.text
+    assert "Route your money onward" in response.text
+
+
+def test_nudge_disappears_once_a_transfer_exists(client: TestClient) -> None:
+    a = _create_channel(client, "Channel A")
+    b = _create_channel(client, "Channel B")
+    period_id = _create_payout_period(client, "15th", "1000", a)
+
+    response = client.post(
+        "/transfers",
+        data={
+            "payout_period_id": period_id,
+            "from_channel_id": a,
+            "to_channel_id": b,
+            "amount": "100",
+        },
+    )
+    assert "nudge-banner" not in response.text
+
+
+def test_dismissing_nudge_clears_it_even_while_still_empty(client: TestClient) -> None:
+    response = client.post("/cashflow/nudge/dismiss")
+    assert response.status_code == 200
+    assert "nudge-banner" not in response.text
+
+    response = client.get("/cashflow")
+    assert "nudge-banner" not in response.text

--- a/tests/test_credit.py
+++ b/tests/test_credit.py
@@ -124,3 +124,27 @@ def test_credit_warn_pill_shown_for_over_limit_line(client: TestClient) -> None:
     assert response.status_code == 200
     assert "warn-red" in response.text
     assert "Over limit" in response.text
+
+
+# --- Onboarding nudge (#138) --------------------------------------------------
+
+
+def test_shows_nudge_when_no_credit_lines_yet(client: TestClient) -> None:
+    response = client.get("/credit")
+    assert response.status_code == 200
+    assert "nudge-banner" in response.text
+    assert "Keep an eye on utilization" in response.text
+
+
+def test_nudge_disappears_once_a_credit_line_exists(client: TestClient) -> None:
+    response = client.post("/credit", data={"name": "Maya Black", "limit": "1000", "used": "0"})
+    assert "nudge-banner" not in response.text
+
+
+def test_dismissing_nudge_clears_it_even_while_still_empty(client: TestClient) -> None:
+    response = client.post("/credit/nudge/dismiss")
+    assert response.status_code == 200
+    assert "nudge-banner" not in response.text
+
+    response = client.get("/credit")
+    assert "nudge-banner" not in response.text

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -266,3 +266,29 @@ def test_goal_round_up_toggle_reflected_on_page(client: TestClient) -> None:
     assert response.status_code == 200
     assert 'name="round_up_to_hundred"' in response.text
     assert re.search(r'name="round_up_to_hundred"[^>]*checked', response.text)
+
+
+# --- Onboarding nudge (#138) --------------------------------------------------
+
+
+def test_shows_nudge_when_no_goals_yet(client: TestClient) -> None:
+    response = client.get("/goals")
+    assert response.status_code == 200
+    assert "nudge-banner" in response.text
+    assert "Save toward something specific" in response.text
+
+
+def test_nudge_disappears_once_a_goal_exists(client: TestClient) -> None:
+    response = client.post(
+        "/goals", data={"name": "Emergency Fund", "target": "1000", "months": "1"}
+    )
+    assert "nudge-banner" not in response.text
+
+
+def test_dismissing_nudge_clears_it_even_while_still_empty(client: TestClient) -> None:
+    response = client.post("/goals/nudge/dismiss")
+    assert response.status_code == 200
+    assert "nudge-banner" not in response.text
+
+    response = client.get("/goals")
+    assert "nudge-banner" not in response.text

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from app import crud
 from app.auth import get_current_user
 from app.main import app
-from tests.conftest import TestingSessionLocal
+from tests.conftest import TEST_USER_ID, TestingSessionLocal
 from tests.conftest import oauth_login as _oauth_login
 
 
@@ -237,3 +237,55 @@ def test_skip_onboarding_requires_login(real_client: TestClient) -> None:
     response = real_client.post("/onboarding/skip", follow_redirects=False)
     assert response.status_code == 303
     assert response.headers["location"] == "/login"
+
+
+# --- Per-section nudge (#138) -------------------------------------------------
+# Crud-level coverage for crud.needs_nudge()/dismiss_nudge() -- the four
+# section-specific TestClient tests (test_goals.py, test_credit.py,
+# test_assets.py, test_cashflow.py) cover the actual pages; these cover the
+# underlying logic directly, including cases none of those four need to
+# repeat (independence between sections, dismissal surviving data later
+# being added).
+
+
+def test_needs_nudge_stays_dismissed_after_data_is_added_later(client: TestClient) -> None:
+    """A dismissal is permanent -- adding data afterwards shouldn't matter,
+    since needs_nudge() already returns False once is_empty=False regardless
+    of the dismissal row. This pins that "dismissed while empty" doesn't
+    somehow get treated differently from "dismissed then later has data"."""
+    user_id = TEST_USER_ID
+    db = TestingSessionLocal()
+    try:
+        assert crud.needs_nudge(db, user_id, "goals", is_empty=True) is True
+        crud.dismiss_nudge(db, user_id, "goals")
+        assert crud.needs_nudge(db, user_id, "goals", is_empty=True) is False
+        # Once real data exists, is_empty=False is passed in by the caller
+        # (goals_page_data) regardless of the dismissal row -- still False.
+        assert crud.needs_nudge(db, user_id, "goals", is_empty=False) is False
+    finally:
+        db.close()
+
+
+def test_needs_nudge_sections_are_independent(client: TestClient) -> None:
+    user_id = TEST_USER_ID
+    db = TestingSessionLocal()
+    try:
+        crud.dismiss_nudge(db, user_id, "goals")
+        assert crud.needs_nudge(db, user_id, "goals", is_empty=True) is False
+        assert crud.needs_nudge(db, user_id, "credit", is_empty=True) is True
+    finally:
+        db.close()
+
+
+def test_dismiss_nudge_is_idempotent(client: TestClient) -> None:
+    """Dismissing an already-dismissed section shouldn't raise (e.g. a
+    duplicate double-click/request) or create a second row -- the
+    UniqueConstraint on (user_id, section) would reject that."""
+    user_id = TEST_USER_ID
+    db = TestingSessionLocal()
+    try:
+        crud.dismiss_nudge(db, user_id, "assets")
+        crud.dismiss_nudge(db, user_id, "assets")
+        assert crud.needs_nudge(db, user_id, "assets", is_empty=True) is False
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
Direction confirmed on the mockup: https://claude.ai/code/artifact/7a5b99c9-dad4-4612-a843-facb7f5561d7

- The existing 3-step Channels -> Payout periods -> Expenses banner on Expenses is **completely untouched** -- it's genuinely sequential/blocking, unlike everything else
- One independent, lightweight nudge banner added to Cash Flow (introducing Transfers), Goals, Credit, and Assets -- real, shipped sections that previously had zero introduction
- New `OnboardingNudge(user_id, section, dismissed_at)` table (additive migration), replacing the "won't scale past 3 `elif`s" concern the issue flagged -- one row per (user, section) instead of overloading `User.onboarding_completed_at`
- `crud.needs_nudge()` shows a nudge only while its section is still empty *and* has no dismissal row; `crud.dismiss_nudge()` records one. Auto-clears the moment either flips (real data added, or dismissed directly) -- same auto-complete spirit as the existing 3-step flow, just per-section
- Nudges share one macro (`macros.nudge_banner`), called once per page with that page's own dismiss route (`POST /{goals,credit,assets,cashflow}/nudge/dismiss`) -- same accent-tinted language as `.onboard-banner`, simplified (no progress bar, no "Step X of Y", since these four are independent, not sequential)
- Cash Flow shows one canvas section per payout period, but the nudge is about the Transfers *feature*, not any one period -- it's a single page-level banner keyed on "any transfers exist at all", not per-period

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` -- 250 passed (15 new: 3 per page x 4 pages covering shows-when-empty / disappears-once-data-exists / dismissing-clears-it-while-still-empty, plus 3 crud-level tests on `needs_nudge`/`dismiss_nudge` directly -- dismissal survives data being added later, sections are independent of each other, dismissing twice doesn't error against the `UniqueConstraint`)
- [x] **Verified the tests aren't vacuous**: temporarily removed the `show_nudge` wiring from `goals_page_data` and confirmed the corresponding test fails, then restored it and confirmed it passes
- [x] Verified all four pages actually render the banner via a direct TestClient check (`nudge-banner` present in the response for `/goals`, `/credit`, `/assets`, `/cashflow` on a fresh account)

Closes #138