### PR TITLE
(feat) cap main content width so it stops stretching on wide monitors

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -212,7 +212,18 @@
   }
 
   .page {
-    @apply flex-1 px-4 py-5 sm:px-6 sm:py-6 md:px-10 md:py-8 bg-paper overflow-y-auto overflow-x-hidden;
+    /* Capped + centered so content stops growing past a comfortable width
+       on a wide monitor instead of stretching tables/forms edge-to-edge --
+       see issue #139. Centering (not left-anchored against the rail) was
+       the user's explicit choice over the alternative shown in the design
+       mockup. max-w-7xl (1280px) rather than .auth-shell's narrower
+       max-w-4xl: this app's own denser tables (Admin's Users table,
+       cycle-history balance tables) need more room than a login card does.
+       .page stays the flex-1 scroll container (overflow-y-auto) -- margin:
+       auto centering it within the flex row's remaining space works the
+       same way .auth-shell already centers itself on the login/signup
+       pages, just as a flex child here instead of a block one. */
+    @apply flex-1 max-w-7xl mx-auto px-4 py-5 sm:px-6 sm:py-6 md:px-10 md:py-8 bg-paper overflow-y-auto overflow-x-hidden;
   }
   .page-head {
     @apply flex items-baseline justify-between gap-3 flex-wrap mb-5;


### PR DESCRIPTION
## Summary
Direction confirmed on the mockup: https://claude.ai/code/artifact/83a1ef82-acba-4974-8532-e9ecbc2f4d88 -- **centered**, chosen over the left-anchored alternative also shown there.

- `.page` (`flex-1`, no max-width) let every table/card/form grow to fill whatever space was left of the viewport once the rail nav was subtracted -- fine on a laptop, uncomfortably long rows/forms on a wide monitor
- Added `max-w-7xl mx-auto` -- content stops growing past 1280px and centers within the remaining flex space, the same way `.auth-shell` already centers itself on login/signup, just as a flex child here instead of a block one
- 1280px rather than `.auth-shell`'s own narrower `max-w-4xl` (896px): this app's denser tables (Admin's Users table, cycle-history balance tables) need more room than a login card does
- Applied once to `.page` itself in `input.css`, so every page template picks it up automatically -- no per-template changes

## Test plan
- [x] `poetry run pytest` -- 250 passed (unaffected, pure CSS change, no test asserts on layout width)
- [ ] Visual confirmation on the actual `dev` deployment that content is centered and capped on a wide viewport -- couldn't verify locally since this dev machine has no `tailwindcss` binary to rebuild `style.css` with the change (same pre-existing local-environment limitation noted on recent PRs); `max-w-7xl`/`mx-auto` are standard, unambiguous Tailwind core utilities

Closes #139