### PR TITLE
(feat) add a favicon, building on the Vantage wordmark from #131

### DIFF
--- a/app/static/favicon.svg
+++ b/app/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#2f56e8" />
+  <text x="16"
+        y="23"
+        font-family="-apple-system, 'Segoe UI', Inter, system-ui, sans-serif"
+        font-weight="800"
+        font-size="19"
+        fill="#ffffff"
+        text-anchor="middle">V</text>
+</svg>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,6 +7,11 @@
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
     <meta name="currency-symbol" content="{{ currency_symbol }}">
     <title>Vantage</title>
+    <link rel="icon"
+          type="image/svg+xml"
+          href="{{ url_for('static', path='favicon.svg') }}">
+    <link rel="apple-touch-icon"
+          href="{{ url_for('static', path='favicon.svg') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
           rel="stylesheet">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
     <title>Log in — Vantage</title>
+    <link rel="icon"
+          type="image/svg+xml"
+          href="{{ url_for('static', path='favicon.svg') }}">
+    <link rel="apple-touch-icon"
+          href="{{ url_for('static', path='favicon.svg') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
           rel="stylesheet">

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ request.session.csrf_token }}">
     <title>Create account — Vantage</title>
+    <link rel="icon"
+          type="image/svg+xml"
+          href="{{ url_for('static', path='favicon.svg') }}">
+    <link rel="apple-touch-icon"
+          href="{{ url_for('static', path='favicon.svg') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
           rel="stylesheet">

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -93,3 +93,18 @@ def test_confirm_and_alert_modals_have_dialog_semantics(client: TestClient) -> N
     assert 'aria-modal="true"' in text
     assert 'aria-describedby="confirm-modal-message"' in text
     assert 'aria-describedby="alert-modal-message"' in text
+
+
+def test_favicon_served_and_linked_on_every_page(client: TestClient) -> None:
+    """Regression test for #132: there was previously no favicon/apple-touch-
+    icon <link> anywhere, on either the authenticated app shell or the
+    standalone login/signup pages."""
+    favicon = client.get("/static/favicon.svg")
+    assert favicon.status_code == 200
+    assert favicon.headers["content-type"].startswith("image/svg+xml")
+
+    for path in ("/", "/login", "/signup"):
+        text = client.get(path).text
+        assert 'rel="icon"' in text
+        assert "static/favicon.svg" in text
+        assert 'rel="apple-touch-icon"' in text


### PR DESCRIPTION
## Summary
The app logo/wordmark itself already shipped in #131 (rail nav, login/signup) -- this is the other half of #132: an actual favicon + apple-touch-icon, neither of which existed at all before.

- New `app/static/favicon.svg` -- an accent-blue rounded-square "V" monogram, reusing the exact same white-bold-on-accent treatment the app's own `.badge` component already uses for channel initials (no new visual language invented). A full "Vantage" wordmark doesn't fit legibly at 16x16/32x32, so this needed its own icon-only mark, built directly on the accent-blue direction #131 established
- Checked legibility directly (rendered at 16/32/64/180px in Chrome) before wiring it up -- readable at all sizes, including actual browser-tab scale
- Linked from every page with its own `<head>`: `base.html` (the authenticated app shell) plus the standalone `login.html`/`signup.html`, which don't extend `base.html`

## Known limitation
SVG covers both `<link rel="icon">` and `apple-touch-icon`. Modern Safari/iOS (15+) supports SVG apple-touch-icons; older iOS versions will just show no icon there rather than break anything -- there's no PNG-generation tooling available in this environment to provide a true raster fallback.

## Test plan
- [x] `poetry run ruff check .` / `ruff format --check .`
- [x] `poetry run mypy app tests`
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run pytest` -- 251 passed (1 new: favicon actually served at `/static/favicon.svg` with the right content-type, and linked with both `rel="icon"` and `rel="apple-touch-icon"` on `/`, `/login`, `/signup`)

Closes #132