### PR TITLE
(fix) remove the rail greeting to stop the top-of-rail jump on collapse

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -51,7 +51,7 @@
   --color-rust: #c53d3d;
   --color-rust-soft: #fbe8e8;
   /* Not a display face any more -- flat/fintech direction dropped the serif
-     look entirely, but .page-title/.rail-greeting still use the font-serif
+     look entirely, but .page-title/.brand-wordmark still use the font-serif
      utility, so this token is repointed to the same sans stack as body text
      rather than touching every template that references it. */
   --font-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
@@ -117,10 +117,14 @@
     @apply flex items-center justify-between px-5 pb-4 mb-3 border-b border-line;
   }
   .rail-brand {
-    @apply flex flex-col gap-1 min-w-0 transition-opacity duration-150;
-  }
-  .rail-greeting {
-    @apply font-serif font-semibold text-sm text-ink truncate;
+    /* Just the wordmark now -- see issue #140. Used to also hold a
+       personalized greeting stacked underneath, but that turned the
+       expanded (row) vs collapsed (column) .rail-head layouts into a much
+       bigger height difference once there were two lines instead of one,
+       making the already-jarring row<->column snap on collapse/expand
+       even more visible. Removed rather than trying to animate the
+       row/column switch itself. */
+    @apply min-w-0 transition-opacity duration-150;
   }
 
   /* Wordmark -- see issue #131. Reused as-is (just a different `size`) in

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,11 +27,7 @@
            hx-swap="innerHTML"
            hx-push-url="true">
         <div class="rail-head" id="rail-head">
-          <div class="rail-brand" id="rail-brand">
-            {{ macros.brand_wordmark() }}
-            {% set greeting_name = current_user.display_name if current_user and current_user.display_name else (current_user.email.split('@')[0] if current_user else '') %}
-            <span class="rail-greeting" title="What's up, {{ greeting_name }}!">What's up, {{ greeting_name }}!</span>
-          </div>
+          <div class="rail-brand" id="rail-brand">{{ macros.brand_wordmark() }}</div>
           <button class="shrink-0 bg-paper-dim text-ink-soft rounded w-6 h-6 flex items-center justify-center cursor-pointer hover:bg-line"
                   id="collapse-toggle"
                   type="button">


### PR DESCRIPTION
## Summary
Follow-up to #143, which fixed the tab-label wrapping mechanism described in #140's original report -- but the reporter confirmed the rail still visibly jumps during collapse/expand, and specifically that #131's wordmark addition made it worse.

## Root cause (distinct from #143's)
\`applyCollapsed()\` toggles \`.rail-head\` between row layout (expanded: brand + collapse-toggle side by side, height = \`max(brand, button)\`) and column layout (collapsed: stacked, height = \`sum(brand, button)\`) via an instant \`classList.toggle\`, not something animated -- that switch was already going to cause *some* height jump. #131 turned \`#rail-brand\` from one line (just the greeting) into two (wordmark stacked above the greeting), which made that jump meaningfully bigger and more visible.

## Fix
Removed the greeting, per the reporter's own suggested fix in the reopened issue -- \`#rail-brand\` is just the wordmark now, back to one line, same as before #131. Simplified the now-single-child \`#rail-brand\`'s CSS to match, and removed the now-unused \`.rail-greeting\` rule.

## Test plan
- [x] Fetched and inspected the **actual compiled CSS from the live `dev` deployment** (not just reasoning about source) to confirm #143's \`whitespace-nowrap\`/\`overflow-hidden\` fix was genuinely deployed and to understand the real row/column height mechanism, since this dev machine can't rebuild \`style.css\` locally
- [x] Confirmed no other template/test references \`.rail-greeting\`/\`greeting_name\`/"What's up" before removing
- [x] \`poetry run ruff check .\` / \`poetry run mypy app tests\`
- [x] \`poetry run djlint app/templates --profile jinja --check\`
- [x] \`poetry run pytest\` -- 251 passed
- [ ] Visual confirmation on the live deployment once merged that the top-of-rail jump is gone

Addresses the reopened #140