### PR TITLE
(fix) stop switching #rail-head between row/column layouts

### DIFF
--- a/app/static/css/input.css
+++ b/app/static/css/input.css
@@ -114,17 +114,33 @@
     @apply w-52 shrink-0 bg-card border-r border-line flex flex-col gap-1 py-5 transition-[width] duration-200 ease-in-out;
   }
   .rail-head {
+    /* Deliberately a *fixed* row layout at every rail width -- base.html's
+       applyCollapsed() used to toggle this into a column layout while
+       collapsed (brand stacked above the collapse-toggle button), which
+       reserves sum(brand-height, gap, button-height) instead of
+       max(brand-height, button-height). That's taller than the row
+       layout, and the classList.toggle() applying it happens instantly on
+       click, not animated in step with .rail's own 200ms width
+       transition -- so for that first frame, .rail-head snaps taller,
+       pushing every .tab below it down, then snaps back once the width
+       animation finishes. Confirmed via a screen recording after the
+       previous fix (removing the greeting, see .rail-brand below) turned
+       out to only shrink the jump, not eliminate it -- row vs column is
+       still two different heights regardless of how many lines .rail-brand
+       holds. Never switching layout mode at all removes the height
+       difference entirely: .rail-brand still fades/clips as the rail
+       narrows (see its own overflow-hidden below), it just never gets a
+       second row to itself. See issue #140. */
     @apply flex items-center justify-between px-5 pb-4 mb-3 border-b border-line;
   }
   .rail-brand {
-    /* Just the wordmark now -- see issue #140. Used to also hold a
-       personalized greeting stacked underneath, but that turned the
-       expanded (row) vs collapsed (column) .rail-head layouts into a much
-       bigger height difference once there were two lines instead of one,
-       making the already-jarring row<->column snap on collapse/expand
-       even more visible. Removed rather than trying to animate the
-       row/column switch itself. */
-    @apply min-w-0 transition-opacity duration-150;
+    /* overflow-hidden so the wordmark clips instead of overflowing/
+       wrapping as .rail-head's fixed row layout (above) narrows along
+       with .rail during the collapse/expand transition -- same
+       whitespace-nowrap/overflow-hidden clipping idea #143 already uses
+       for .tab-label, applied here since .rail-head no longer switches to
+       a column layout to give this room. */
+    @apply min-w-0 overflow-hidden transition-opacity duration-150;
   }
 
   /* Wordmark -- see issue #131. Reused as-is (just a different `size`) in

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,7 +26,7 @@
            hx-target="#page-content"
            hx-swap="innerHTML"
            hx-push-url="true">
-        <div class="rail-head" id="rail-head">
+        <div class="rail-head">
           <div class="rail-brand" id="rail-brand">{{ macros.brand_wordmark() }}</div>
           <button class="shrink-0 bg-paper-dim text-ink-soft rounded w-6 h-6 flex items-center justify-center cursor-pointer hover:bg-line"
                   id="collapse-toggle"
@@ -304,7 +304,6 @@
       applyTheme();
 
       const rail = document.getElementById("rail");
-      const railHead = document.getElementById("rail-head");
       const railBrand = document.getElementById("rail-brand");
       const icon = document.getElementById("collapse-icon");
       const labels = () => document.querySelectorAll(".tab-label");
@@ -321,9 +320,6 @@
       function applyCollapsed(collapsed, { animate = true } = {}) {
         rail.classList.toggle("w-52", !collapsed);
         rail.classList.toggle("w-16", collapsed);
-        railHead.classList.toggle("flex-col", collapsed);
-        railHead.classList.toggle("gap-2", collapsed);
-        railHead.classList.toggle("justify-between", !collapsed);
         icon.textContent = collapsed ? "›" : "‹";
 
         clearTimeout(fadeHideTimeout);


### PR DESCRIPTION
## Summary
Third round on #140. #151 (removing the greeting) reduced the jump but the reporter's screen recording showed it wasn't fully gone -- confirmed by extracting frames from the recording locally (no direct way to view video), showing `.rail-head` mid-transition in its column layout with every `.tab` below shifted down ~32px versus both the starting and settled frames.

## Root cause (more precisely this time)
`applyCollapsed()` still toggled `.rail-head` between a row layout (expanded, height = `max(brand, button)`) and a column layout (collapsed, height = `sum(brand, gap, button)`) via `classList.toggle("flex-col", ...)`, applied instantly on click rather than animated in step with `.rail`'s own 200ms width transition. That height difference exists **regardless of how many lines `.rail-brand` holds** -- #151 only shrank it (two lines -> one), it couldn't eliminate it without removing the layout switch itself.

## Fix
`.rail-head` is a fixed row layout at every rail width now -- no more row/column toggle, so there's no second height to snap to. Added `overflow-hidden` to `.rail-brand` so the wordmark clips as the row narrows during the transition instead of needing a column layout to have room to fade in place, same clipping approach #143 already uses for `.tab-label`. Also removed the now-dead `#rail-head` id/JS reference (nothing reads it any more).

## Test plan
- [x] `poetry run djlint app/templates --profile jinja --check`
- [x] `poetry run ruff check .`
- [x] `poetry run pytest` -- 251 passed (unaffected, JS/CSS only)
- [ ] Live confirmation once merged, with another recording/click-through if needed

Addresses the reopened #140