### PR TITLE
(feat) mask user emails in the admin dashboard

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1817,6 +1817,18 @@ ORPHANABLE_MODELS: tuple[type[Any], ...] = (
 )
 
 
+def mask_email(email: str) -> str:
+    """Partially obscure an email for display in the admin dashboard --
+    keeps the first couple of local-part characters and the full domain
+    (still useful for an admin to recognize/distinguish accounts) but
+    replaces the rest of the local part with asterisks."""
+    local, _, domain = email.partition("@")
+    if not domain:
+        return "*" * len(email)
+    visible = local[:2]
+    return f"{visible}{'*' * max(1, len(local) - len(visible))}@{domain}"
+
+
 def list_users_for_admin(db: Session) -> list[dict[str, Any]]:
     users = list(db.scalars(select(models.User).order_by(models.User.created_at.desc())))
     rows = []
@@ -1848,6 +1860,7 @@ def list_users_for_admin(db: Session) -> list[dict[str, Any]]:
         rows.append(
             {
                 "user": user,
+                "masked_email": mask_email(user.email),
                 "providers": providers,
                 "channel_count": channel_count,
                 "expense_count": expense_count,

--- a/app/templates/partials/admin_page.html
+++ b/app/templates/partials/admin_page.html
@@ -51,8 +51,8 @@
             {% set user = row.user %}
             <tr>
               <td data-label="Email">
-                {{ user.display_name or user.email }}
-                {% if user.display_name %}<div class="text-[11px] text-ink-soft">{{ user.email }}</div>{% endif %}
+                {{ user.display_name or row.masked_email }}
+                {% if user.display_name %}<div class="text-[11px] text-ink-soft">{{ row.masked_email }}</div>{% endif %}
               </td>
               <td data-label="Signed up">{{ user.created_at.strftime("%Y-%m-%d") }}</td>
               <td data-label="Providers">
@@ -78,7 +78,7 @@
                           hx-post="/admin/users/{{ user.id }}/delete"
                           hx-target="#admin-page"
                           hx-swap="outerHTML"
-                          hx-confirm="Delete {{ user.email }} and all of their data? This can't be undone.">{{ macros.icon_delete() }}</button>
+                          hx-confirm="Delete {{ user.display_name or row.masked_email }} and all of their data? This can't be undone.">{{ macros.icon_delete() }}</button>
                 {% endif %}
               </td>
             </tr>
@@ -208,7 +208,7 @@
                                 required>
                           <option value="">Choose a user&hellip;</option>
                           {% for row in users %}
-                            <option value="{{ row.user.id }}">{{ row.user.email }}</option>
+                            <option value="{{ row.user.id }}">{{ row.user.display_name or row.masked_email }}</option>
                           {% endfor %}
                         </select>
                         <button class="btn-secondary" type="submit">Assign</button>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -32,7 +32,25 @@ def test_admin_can_view_dashboard(client: TestClient, as_admin: None) -> None:
     response = client.get("/admin")
     assert response.status_code == 200
     assert "Admin" in response.text
-    assert "test@example.com" in response.text
+    assert "te**@example.com" in response.text
+
+
+def test_admin_dashboard_masks_user_emails(client: TestClient, as_admin: None, db: Session) -> None:
+    """Regression test: raw emails shouldn't leak into the admin dashboard's
+    HTML anywhere -- the user list or the orphan-assignment dropdown --
+    only the masked form should appear."""
+    other = crud.create_user(db, "somebody@example.com")
+    crud.create_channel(db, schemas.ChannelCreate(name="Orphan Wallet"), user_id=None)
+    db.commit()
+    other_id = other.id
+
+    response = client.get("/admin")
+    assert response.status_code == 200
+    assert "test@example.com" not in response.text
+    assert "somebody@example.com" not in response.text
+    assert "te**@example.com" in response.text
+    assert "so******@example.com" in response.text
+    assert f'<option value="{other_id}">so******@example.com</option>' in response.text
 
 
 def test_admin_dashboard_shows_orphan_counts(


### PR DESCRIPTION
## Summary
- Adds `crud.mask_email()` (keeps the first ~2 local-part chars + full domain, e.g. `te**@example.com`) and computes `masked_email` per row in `list_users_for_admin()`.
- Admin dashboard's user table, delete-confirmation dialog, and orphan-assignment dropdown now show the masked email (falling back to `display_name` first, same as before) instead of the raw address.

## Test plan
- [x] `poetry run pytest tests/test_admin.py -q` — new `test_admin_dashboard_masks_user_emails` asserts raw emails are absent and masked forms are present across all three surfaces
- [x] `poetry run ruff check .` / `ruff format --check .` / `mypy app tests` / `djlint --check`
- [x] Full `poetry run pytest` (252 passed)

Closes #155

https://claude.ai/code/session_01V8o1jP4TGDZqqfkEAAG6Co