### PR TITLE
(feat) editable channel current_amount wired to payout closing

### DIFF
--- a/alembic/versions/6a0d7980bcab_add_channel_current_amount.py
+++ b/alembic/versions/6a0d7980bcab_add_channel_current_amount.py
@@ -1,0 +1,29 @@
+"""add channel current_amount
+
+Revision ID: 6a0d7980bcab
+Revises: 9c3f0e5a1b7d
+Create Date: 2026-08-22 09:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '6a0d7980bcab'
+down_revision: Union[str, None] = '9c3f0e5a1b7d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'channels',
+        sa.Column(
+            'current_amount', sa.Numeric(10, 2), nullable=False, server_default='0'
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('channels', 'current_amount')

--- a/app/crud.py
+++ b/app/crud.py
@@ -400,6 +400,7 @@ def update_channel(
         channel.name = data.name
         channel.color = data.color
         channel.channel_type = data.channel_type
+        channel.current_amount = data.current_amount
         db.commit()
         db.refresh(channel)
     return channel
@@ -1048,7 +1049,11 @@ def _all_channel_balances(
 
     carry_in_by_period: dict[int, dict[int, float]] = {}
     balances_by_period: dict[int, list[tuple[models.Channel, float]]] = {}
-    carry: dict[int, float] = {}
+    # Seeded from each channel's persistent "Actual" balance (see issue #162)
+    # rather than an implicit 0 -- this is the single choke point every caller
+    # (channel_balances, cashflow_page_data, preview_canvas, _live_cycle_balances)
+    # inherits the baseline through.
+    carry: dict[int, float] = {c.id: float(c.current_amount) for c in channels}
     for period in periods:
         carry_in_by_period[period.id] = carry
         expenses = [e for e in all_expenses if e.payout_period_id == period.id]
@@ -1211,12 +1216,23 @@ def close_payout_cycle(db: Session, payout_period_id: int, user_id: int) -> mode
     The live template (period, its transfers, its expenses) is left
     completely untouched -- closing a cycle is purely additive, so there's
     no data-loss risk and no "did I already close this month" bookkeeping
-    to get wrong. See issue #84."""
+    to get wrong. See issue #84.
+
+    Also increments each channel's persistent Channel.current_amount ("Actual"
+    balance, see issue #162) by this period's own delta (net - carry_in), not
+    the full carried net -- PayoutPeriod is a reused recurring template, not a
+    dated one-off, so crediting the full net would double-count a channel's
+    already-counted carry-in on every subsequent close."""
     period = _owned(db, models.PayoutPeriod, payout_period_id, user_id)
     if period is None:
         raise OwnershipError("Payout period not found.")
 
     live_balances = _live_cycle_balances(db, period, user_id)
+
+    channels = list_channels(db, user_id)
+    carry_in_by_period, balances_by_period = _all_channel_balances(db, user_id)
+    carry_in = carry_in_by_period.get(payout_period_id, {})
+    net_by_channel_id = {c.id: net for c, net in balances_by_period.get(payout_period_id, [])}
 
     cycle = models.PayoutCycle(
         user_id=user_id,
@@ -1233,6 +1249,10 @@ def close_payout_cycle(db: Session, payout_period_id: int, user_id: int) -> mode
     for balance in live_balances:
         balance.payout_cycle_id = cycle.id
         db.add(balance)
+
+    for channel in channels:
+        delta = net_by_channel_id.get(channel.id, 0.0) - carry_in.get(channel.id, 0.0)
+        channel.current_amount = float(channel.current_amount) + delta
 
     db.commit()
     db.refresh(cycle)

--- a/app/models.py
+++ b/app/models.py
@@ -97,6 +97,11 @@ class Channel(Base):
     badge_label: Mapped[str | None] = mapped_column(String(4), nullable=True)
     logo_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     logo_mimetype: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # User-editable running "Actual" balance, distinct from the fully-recomputed
+    # live "Projected" chain -- see issue #162. Seeds the carry-in baseline in
+    # _all_channel_balances and is incremented (by a period's own delta, not its
+    # full carried net) when a payout cycle is closed.
+    current_amount: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
 
 
 class PayoutPeriod(Base):

--- a/app/routers/channels.py
+++ b/app/routers/channels.py
@@ -60,6 +60,7 @@ async def update_channel(
     name: str = Form(...),
     color: str = Form(...),
     channel_type: str = Form(""),
+    current_amount: float = Form(0),
     logo: UploadFile | None = File(None),
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
@@ -68,7 +69,12 @@ async def update_channel(
     crud.update_channel(
         db,
         channel_id,
-        schemas.ChannelUpdate(name=name, color=color, channel_type=channel_type or None),
+        schemas.ChannelUpdate(
+            name=name,
+            color=color,
+            channel_type=channel_type or None,
+            current_amount=current_amount,
+        ),
         current_user.id,
     )
     if logo_payload is not None:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -20,6 +20,7 @@ class ChannelUpdate(BaseModel):
     name: NonEmptyStr
     color: str
     channel_type: str | None = None
+    current_amount: float = 0
 
 
 class PayoutPeriodCreate(BaseModel):

--- a/app/templates/partials/expenses_page.html
+++ b/app/templates/partials/expenses_page.html
@@ -51,12 +51,14 @@
         <colgroup>
           <col class="min-w-28">
           <col class="w-36">
+          <col class="w-32">
           <col class="w-28">
         </colgroup>
         <thead>
           <tr>
             <th>Name</th>
             <th>Type</th>
+            <th class="text-right">Actual balance</th>
             <th></th>
           </tr>
         </thead>
@@ -120,6 +122,19 @@
                   </select>
                 </div>
               </td>
+              <td class="num" data-label="Actual balance">
+                <span class="view-channel-{{ channel.id }}">{{ macros.peso(channel.current_amount) }}</span>
+                <div class="edit-channel-{{ channel.id }} hidden items-center justify-end gap-1">
+                  <span class="text-ink-soft text-sm">{{ currency_symbol }}</span>
+                  <input class="field field-mono w-24"
+                         type="number"
+                         step="0.01"
+                         name="current_amount"
+                         form="channel-edit-form-{{ channel.id }}"
+                         aria-label="Actual balance"
+                         value="{{ channel.current_amount }}">
+                </div>
+              </td>
               <td class="led-actions">
                 <div class="view-channel-{{ channel.id }} flex items-center gap-1">
                   <button type="button"
@@ -150,7 +165,7 @@
               </td>
             </tr>
           {% else %}
-            {{ macros.empty_row(3, 'channels') }}
+            {{ macros.empty_row(4, 'channels') }}
           {% endfor %}
         </tbody>
       </table>

--- a/app/templates/partials/payout_cycle_history_page.html
+++ b/app/templates/partials/payout_cycle_history_page.html
@@ -55,7 +55,7 @@
             <th class="text-right">Income</th>
             <th class="text-right">Transfers</th>
             <th class="text-right">Expenses</th>
-            <th class="text-right">Net</th>
+            <th class="text-right">{{ "Net" if selected_cycle else "Net (Projected)" }}</th>
           </tr>
         </thead>
         <tbody>

--- a/tests/test_channel_current_amount.py
+++ b/tests/test_channel_current_amount.py
@@ -1,0 +1,124 @@
+import re
+
+from fastapi.testclient import TestClient
+
+from app import crud, models, schemas
+from tests.conftest import TEST_USER_ID, TestingSessionLocal
+
+
+def _create_channel(client: TestClient, name: str) -> str:
+    response = client.post("/channels", data={"name": name, "color": "#8a8a8a"})
+    match = re.search(rf'value="{re.escape(name)}">.*?/channels/(\d+)"', response.text, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _create_payout_period(client: TestClient, income: str, channel_id: str) -> str:
+    response = client.post(
+        "/payout-periods",
+        data={"label": "15th", "income_amount": income, "receiving_channel_id": channel_id},
+    )
+    matches = re.findall(r"/payout-periods/(\d+)", response.text)
+    assert matches
+    return matches[-1]
+
+
+def test_current_amount_defaults_to_zero_and_renders(client: TestClient) -> None:
+    response = client.get("/expenses")
+    assert response.status_code == 200
+    assert "Actual balance" in response.text
+
+
+def test_update_channel_sets_current_amount(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Maya Wallet")
+
+    response = client.patch(
+        f"/channels/{channel_id}",
+        data={"name": "Maya Wallet", "color": "#8a8a8a", "current_amount": "500.25"},
+    )
+    assert response.status_code == 200
+    assert "500.25" in response.text
+
+    db = TestingSessionLocal()
+    try:
+        channel = db.get(models.Channel, int(channel_id))
+        assert channel is not None
+        assert float(channel.current_amount) == 500.25
+    finally:
+        db.close()
+
+
+def test_current_amount_seeds_carry_in_for_first_period(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Maya Wallet")
+    client.patch(
+        f"/channels/{channel_id}",
+        data={"name": "Maya Wallet", "color": "#8a8a8a", "current_amount": "500"},
+    )
+    period_id = _create_payout_period(client, "1000", channel_id)
+
+    live = client.get(f"/payout-periods/{period_id}/cycles")
+    assert live.status_code == 200
+    # 500 (Actual baseline) + 1000 (this period's income) = 1500.
+    assert "1,500.00" in live.text
+
+
+def test_close_payout_cycle_increments_by_period_delta_not_full_net(client: TestClient) -> None:
+    channel_id = _create_channel(client, "Maya Wallet")
+    client.patch(
+        f"/channels/{channel_id}",
+        data={"name": "Maya Wallet", "color": "#8a8a8a", "current_amount": "500"},
+    )
+    period_id = _create_payout_period(client, "1000", channel_id)
+
+    client.post(f"/payout-periods/{period_id}/cycles")
+
+    db = TestingSessionLocal()
+    try:
+        channel = db.get(models.Channel, int(channel_id))
+        assert channel is not None
+        # delta = net(1500) - carry_in(500) = 1000, so current_amount = 500 + 1000 = 1500,
+        # NOT the full net (1500) added on top of the existing 500 (which would be 2000).
+        assert float(channel.current_amount) == 1500.0
+    finally:
+        db.close()
+
+    # Closing again (same period, unchanged) re-derives carry-in from the
+    # now-updated current_amount (1500), so the delta this time is another
+    # 1000 -- this period is a recurring template, so a second close
+    # legitimately represents receiving this income again, not a double-count
+    # of the first close.
+    client.post(f"/payout-periods/{period_id}/cycles")
+    db = TestingSessionLocal()
+    try:
+        channel = db.get(models.Channel, int(channel_id))
+        assert channel is not None
+        assert float(channel.current_amount) == 2500.0
+    finally:
+        db.close()
+
+
+def test_current_amount_edit_is_isolated_per_user() -> None:
+    db = TestingSessionLocal()
+    try:
+        other_user_id = TEST_USER_ID + 1
+        db.add(models.User(id=other_user_id, email="other@example.com"))
+        db.commit()
+        other_channel = crud.create_channel(
+            db, schemas.ChannelCreate(name="Someone Else's Wallet"), other_user_id
+        )
+        other_channel_id = other_channel.id
+
+        result = crud.update_channel(
+            db,
+            other_channel_id,
+            schemas.ChannelUpdate(name="Hijacked", color="#000000", current_amount=999),
+            TEST_USER_ID,
+        )
+        assert result is None
+
+        untouched = db.get(models.Channel, other_channel_id)
+        assert untouched is not None
+        assert untouched.name == "Someone Else's Wallet"
+        assert float(untouched.current_amount) == 0.0
+    finally:
+        db.close()

--- a/tests/test_payout_cycles.py
+++ b/tests/test_payout_cycles.py
@@ -126,7 +126,13 @@ def test_editing_live_transfer_after_close_does_not_change_the_snapshot(
 
     live = client.get(f"/payout-periods/{period_id}/cycles")
     assert "-₱450.00" in live.text  # live view reflects the edit
-    assert "₱550.00" in live.text  # and the balance recomputed from it (1000 - 450)
+    # Not ₱550.00 (1000 - 450) -- closing the cycle above incremented Channel
+    # A's persistent current_amount by its delta (700 - 0 = 700, see #162),
+    # and _all_channel_balances seeds the live/"Projected" recompute's carry-in
+    # from that same current_amount. So the live view now correctly includes
+    # that baseline too: 700 (carried Actual) + 1000 (income) - 450 (edited
+    # transfer) = 1250.
+    assert "₱1,250.00" in live.text
 
 
 def test_cycle_history_requires_ownership(client: TestClient) -> None:

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -278,7 +278,10 @@ def test_channel_balances_carry_forward_across_many_periods() -> None:
             assert balance_by_channel[channel_a.id] == pytest.approx(expected[i][0])
             assert balance_by_channel[channel_b.id] == pytest.approx(expected[i][1])
             if i == 0:
-                assert entry["carry_in"] == {}
+                # Seeded from each channel's Channel.current_amount (default 0
+                # here, see issue #162), not an empty dict -- period 0 has no
+                # prior period, but it does have this baseline.
+                assert entry["carry_in"] == {channel_a.id: 0.0, channel_b.id: 0.0}
             else:
                 assert entry["carry_in"][channel_a.id] == pytest.approx(expected[i - 1][0])
                 assert entry["carry_in"][channel_b.id] == pytest.approx(expected[i - 1][1])


### PR DESCRIPTION
Closes #162

## Summary
- New persistent `Channel.current_amount` ("Actual" balance), editable anytime via the existing channel edit row on Expenses.
- `_all_channel_balances` now seeds its carry-in baseline from each channel's `current_amount` instead of an implicit 0 -- the single choke point every balance caller (`channel_balances`, `cashflow_page_data`, `preview_canvas`, `_live_cycle_balances`) inherits from.
- `close_payout_cycle` increments `current_amount` by the closed period's own delta (`net - carry_in`), not the full carried `net` -- since `PayoutPeriod` is a reused recurring template, crediting the full net on every close would double-count.
- Cycle-history's live-template view relabels its "Net" column to "Net (Projected)" to distinguish the fully-recomputed live figure from the new persisted Actual balance -- the snapshot view's "Net" is unchanged (it's a locked historical number, not a projection).
- New additive migration for `channels.current_amount`.

## Notes for reviewers
- Two pre-existing tests needed updated expectations, not because of a bug but because of the new (intended) baseline-seeding behavior:
  - `test_transfers.py::test_channel_balances_carry_forward_across_many_periods` -- period 0's `carry_in` is no longer `{}`, it's each channel's `current_amount` (0.0 by default here).
  - `test_payout_cycles.py::test_editing_live_transfer_after_close_does_not_change_the_snapshot` -- after closing a cycle, the live/Projected recompute for that same period now correctly includes the baseline the close just established, so editing a live transfer afterward yields a different (larger) number than before this issue -- the *snapshot* itself is still provably unaffected (that's what this test exists to guard).
- New `tests/test_channel_current_amount.py` covers: editing persists, seeding into the balance chain, the delta-not-full-net increment across two consecutive closes, and per-user ownership isolation via `crud.update_channel`.

## Test plan
- [x] `ruff check .` / `ruff format --check .` / `mypy app tests` / `djlint --check` / `pytest` (261 passed)
- [x] Manually verified in a rendered browser snapshot: Actual balance column shows/edits correctly, edit-mode input carries the right value, "Net (Projected)" label renders on the live view after closing a cycle.